### PR TITLE
feat: auto-persist knowledge tier data across all commands

### DIFF
--- a/commands/audit.md
+++ b/commands/audit.md
@@ -131,6 +131,54 @@ Then inform user: "Findings saved to `docs/findings/audit-YYYY-MM-DD.md`. Run `/
 
 ---
 
+### Step 6c — Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+For each 🔴 or 🟡 finding from the synthesis report:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding new "$(cat <<'EOF'
+{"id":"[FINDING_ID]","source":"audit","severity":"[high|medium]","confidence":"[HIGH|MEDIUM|LOW]","location":"[file:line]","category":"[sector/criterion]","description":"[one-line description]","impact":"[why it matters]","remediation":"[fix description]","effort":"[quick|medium|large]"}
+EOF
+)"
+```
+
+Record the audit verdict:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'full-audit' "$(cat <<'SUMMARY'
+Audit [date]: [N] findings ([M] 🔴 / [P] 🟡 / [Q] 🔵) across [sector_count] sectors
+SUMMARY
+)" "$(cat <<'DETAIL'
+[1-sentence posture summary]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Record the audit verdict (significant enough for the active working set):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision 'full-audit' "$(cat <<'SUMMARY'
+Audit [date]: [N] findings across [sector_count] sectors
+SUMMARY
+)" "$(cat <<'DETAIL'
+[1-sentence posture summary]
+DETAIL
+)"
+```
+
+Prune stale decisions:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js prune
+```
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -47,6 +47,49 @@ The brainstorming skill includes a hard gate against premature implementation. E
 
 ---
 
+### Persist to knowledge tier
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+Using the same `SCRIPTS_DIR` resolved earlier for the locked-decisions query:
+
+Record the design decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision "$(cat <<'TOPIC'
+design-[feature-name]
+TOPIC
+)" "$(cat <<'SUMMARY'
+[date]: [chosen approach name/summary]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[1-2 sentences: what was decided and key trade-offs considered]
+DETAIL
+)"
+```
+
+If any decisions should be locked (user said "lock this" or the decision is a hard constraint):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js query "UPDATE decisions SET status = 'locked' WHERE topic = '[topic]'"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Only record if the decision is locked — unlocked design decisions go to postgres only to avoid bloating DECISIONS.md:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision "$(cat <<'TOPIC'
+[LOCKED] design-[feature-name]
+TOPIC
+)" "$(cat <<'SUMMARY'
+[chosen approach]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[key trade-offs]
+DETAIL
+)"
+```
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/build.md
+++ b/commands/build.md
@@ -61,6 +61,45 @@ Do NOT pass conversation history, prior task results, or accumulated context. Ea
 
 ---
 
+### Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+Record the build session (use `query "SELECT COALESCE(MAX(number),0)+1 FROM sessions"` to get next session number):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update session [next_number] [test_count] "$(cat <<'EOF'
+Build: [N] tasks executed from plan [plan-name]
+EOF
+)"
+```
+
+For each completed task, update its status:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task [task_id] done
+```
+
+For any deferred tasks:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task [task_id] deferred
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Record session only (auto-rotates to keep 5 most recent):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js session [next_number] [test_count] "$(cat <<'EOF'
+Build: [N] tasks executed from plan [plan-name]
+EOF
+)"
+```
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -159,6 +159,30 @@ Run each command in `commit.post_commit_hooks[]` sequentially.
 
 ---
 
+### Persist to knowledge tier
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+**Script path:** Use the resolved `SCRIPTS_DIR` from Step 6 (`$PIPELINE_DIR` or fallback paths).
+
+Record the commit as a decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision "$(cat <<'TOPIC'
+commit-[short_sha]
+TOPIC
+)" "$(cat <<'SUMMARY'
+[commit type](scope): [commit summary] ([short SHA])
+SUMMARY
+)" "$(cat <<'DETAIL'
+[N] files changed. [brief description of what changed and why]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:** No writes — commits are too frequent; decisions per commit would bloat DECISIONS.md.
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/debug.md
+++ b/commands/debug.md
@@ -48,3 +48,49 @@ Then follow the debugging skill's 4-phase protocol. **Critical: if 3+ fix attemp
 
 If confidence in the root cause is LOW, do NOT implement a fix. Report the uncertainty and gather more evidence.
 ```
+
+---
+
+### Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+Store the root cause and fix as a gotcha:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update gotcha new "$(cat <<'TITLE'
+[error class]: [root cause in one line]
+TITLE
+)" "$(cat <<'RULE'
+[fix applied — what to do if this recurs]
+RULE
+)"
+```
+
+Record the debug decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'debug-resolution' "$(cat <<'SUMMARY'
+[date]: [error class] — [root cause]. Confidence: [HIGH/MEDIUM/LOW]
+SUMMARY
+)" "$(cat <<'DETAIL'
+Fix: [file:line — what changed]. Verified: [verification result]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Store the root cause (debug gotchas are always worth recording):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js gotcha "$(cat <<'TITLE'
+[error class]: [root cause in one line]
+TITLE
+)" "$(cat <<'RULE'
+[fix applied — what to do if this recurs]
+RULE
+)"
+```

--- a/commands/finish.md
+++ b/commands/finish.md
@@ -152,6 +152,62 @@ For Option 4: keep worktree.
 
 ---
 
+### Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+Record the session (use `query "SELECT COALESCE(MAX(number),0)+1 FROM sessions"` to get next session number):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update session [next_number] [test_count] "$(cat <<'EOF'
+Finish: merged [feature-branch] to [base-branch]. [option chosen]
+EOF
+)"
+```
+
+Record the decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'branch-completion' "$(cat <<'SUMMARY'
+Merged [feature-branch] to [base-branch] [date]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[1-sentence summary of what the branch accomplished]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Record session (auto-rotates to keep 5 most recent):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js session [next_number] [test_count] "$(cat <<'EOF'
+Finish: merged [feature-branch] to [base-branch]
+EOF
+)"
+```
+
+Record the decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision 'branch-completion' "$(cat <<'SUMMARY'
+Merged [feature-branch] to [base-branch] [date]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[1-sentence summary of what the branch accomplished]
+DETAIL
+)"
+```
+
+Prune stale decisions:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js prune
+```
+
+---
+
 ### Safety rules
 
 - Never proceed with failing tests

--- a/commands/markdown-review.md
+++ b/commands/markdown-review.md
@@ -158,6 +158,38 @@ If fixes were applied, stage all modified files and commit. Use the co-author fr
 
 ---
 
+### Step 5b — Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+For each HIGH or MEDIUM finding:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding new "$(cat <<'EOF'
+{"id":"[MR-XXX-NNN]","source":"markdown-review","severity":"[high|medium|low]","confidence":"[HIGH|MEDIUM|LOW]","location":"[file:line]","category":"[HYG|ARCH|A2A]","description":"[one-line description]","impact":"[effect on agent behavior or maintainability]","remediation":"[fix description]","effort":"[quick|medium|architectural]"}
+EOF
+)"
+```
+
+Record the review outcome:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'markdown-review' "$(cat <<'SUMMARY'
+MR [date]: [N] findings ([H] HIGH / [M] MEDIUM / [L] LOW). Fixed: [F]
+SUMMARY
+)" "$(cat <<'DETAIL'
+Scope: [N] files ([total] lines). Tiers: [tiers]. [remaining] architectural findings unfixed.
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:** No writes — findings already saved to `docs/findings/markdown-review-*.md` in Step 7.
+
+---
+
 ### Step 6 — Dashboard regeneration
 
 If `dashboard.enabled` is true (or `docs/dashboard.html` already exists): locate the dashboard skill (`$PIPELINE_DIR/skills/dashboard/SKILL.md` or Glob `**/pipeline/skills/dashboard/SKILL.md`) and follow it to regenerate `docs/dashboard.html`.

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -35,6 +35,41 @@ If the spec is too vague to produce this level of detail, stop and report: "Spec
 
 ---
 
+### Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+For each task in the plan, create a task record:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task new "$(cat <<'TITLE'
+[task title from plan]
+TITLE
+)" 'build'
+```
+
+Record the planning decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision "$(cat <<'TOPIC'
+plan-[feature-name]
+TOPIC
+)" "$(cat <<'SUMMARY'
+Plan [date]: [N] tasks from spec [spec-name]
+SUMMARY
+)" "$(cat <<'DETAIL'
+Saved to [plan file path]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:** No writes — tasks are in the plan file, decisions would bloat DECISIONS.md.
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/purpleteam.md
+++ b/commands/purpleteam.md
@@ -263,21 +263,26 @@ EOF
 
 **Shell safety:** All comment bodies use heredocs with single-quoted delimiters (`<<'EOF'`) to prevent injection from report-derived content.
 
-**Knowledge tier — Postgres (if `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`):**
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
 
 For each VERIFIED finding:
 ```bash
-node scripts/pipeline-db.js update finding [ID] status verified
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding [ID] status verified
 ```
 
 For each REGRESSION or INCOMPLETE finding (fix did not hold — set back to in_progress):
 ```bash
-node scripts/pipeline-db.js update finding [ID] status in_progress
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding [ID] status in_progress
 ```
 
 For each defensive rule (if `purpleteam.defensive_rules` is true):
 ```bash
-node scripts/pipeline-db.js update gotcha new "$(cat <<'TITLE'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update gotcha new "$(cat <<'TITLE'
 [rule title]
 TITLE
 )" "$(cat <<'DESC'
@@ -288,7 +293,7 @@ DESC
 
 Record the decision:
 ```bash
-node scripts/pipeline-db.js update decision 'purple-team-verification' "$(cat <<'SUMMARY'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'purple-team-verification' "$(cat <<'SUMMARY'
 [date]: [V] verified, [R] regression, [I] incomplete. Posture: [POSTURE_RATING]
 SUMMARY
 )" "$(cat <<'DETAIL'
@@ -297,13 +302,33 @@ DETAIL
 )"
 ```
 
-**Knowledge tier — files (if `knowledge.tier` is `"files"`):**
+**If `knowledge.tier` is `"files"`:**
 
-If `purpleteam.defensive_rules` is true, append each defensive rule to `docs/gotchas.md`:
-```markdown
-### [Rule category] — [Pattern name]
-**Rule:** [Description]
-**Source:** Purple team verification [date], finding [ID]
+For each CRITICAL or HIGH defensive rule only (if `purpleteam.defensive_rules` is true):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js gotcha "$(cat <<'TITLE'
+[Rule category] — [Pattern name]
+TITLE
+)" "$(cat <<'RULE'
+[Description]. Source: Purple team [date], finding [ID]
+RULE
+)"
+```
+
+Record the decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision 'purple-team-verification' "$(cat <<'SUMMARY'
+[date]: [V] verified, [R] regression, [I] incomplete. Posture: [POSTURE_RATING]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[posture summary — 1-2 sentences]
+DETAIL
+)"
+```
+
+Prune stale decisions:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js prune
 ```
 
 **Write the verification report** to `docs/findings/purpleteam-YYYY-MM-DD.md`:

--- a/commands/redteam.md
+++ b/commands/redteam.md
@@ -326,39 +326,80 @@ Report: "HTML report saved to `docs/findings/redteam-[date].html` — open in an
 
 ### Step 9 — Persist to knowledge tier
 
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+Store the resolved absolute path. Use `PROJECT_ROOT=$(pwd) node [scripts_dir]/...` for all commands below.
+
 **If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
 
 Record the session:
 ```bash
-node scripts/pipeline-db.js update session [next_session_number] 0 'Red team assessment: [N] findings ([C] critical, [H] high, [M] medium, [L] low)'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update session [next_session_number] 0 "$(cat <<'EOF'
+Red team assessment: [N] findings ([C] critical, [H] high, [M] medium, [L] low)
+EOF
+)"
 ```
 
 For each CRITICAL or HIGH finding, store as a gotcha:
 ```bash
-node scripts/pipeline-db.js update gotcha new '[finding ID: brief summary]' '[remediation action]'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update gotcha new "$(cat <<'TITLE'
+[finding ID]: [brief summary]
+TITLE
+)" "$(cat <<'RULE'
+[remediation action]
+RULE
+)"
 ```
 
 Record the decision:
 ```bash
-node scripts/pipeline-db.js update decision 'security-assessment' 'Red team [date]: [overall verdict]' '[summary of security posture and key risks]'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'security-assessment' "$(cat <<'SUMMARY'
+Red team [date]: [overall verdict]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[summary of security posture and key risks]
+DETAIL
+)"
 ```
 
 **If `knowledge.tier` is `"files"`:**
 
-Append a session summary to `docs/sessions/`:
-```
-## Session [N] — Red Team Assessment
-
-**Date:** [date]
-**Tests passing:** N/A (assessment only)
-**Summary:** Security assessment with [N] specialists. Found [C] critical, [H] high, [M] medium, [L] low findings.
-**Key findings:** [list critical/high finding summaries]
+Record session (auto-rotates to keep 5 most recent):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js session [next_session_number] 0 "$(cat <<'EOF'
+Red team assessment: [N] findings ([C] critical, [H] high, [M] medium, [L] low)
+EOF
+)"
 ```
 
-If critical or high findings exist, append to `docs/gotchas.md`:
+For each CRITICAL or HIGH finding only, store as a gotcha:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js gotcha "$(cat <<'TITLE'
+[finding ID]: [brief summary]
+TITLE
+)" "$(cat <<'RULE'
+[remediation action]
+RULE
+)"
 ```
-### [finding ID] — [brief description]
-**Rule:** [remediation action]
+
+Record the decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision 'security-assessment' "$(cat <<'SUMMARY'
+Red team [date]: [overall verdict]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[summary of security posture and key risks]
+DETAIL
+)"
+```
+
+Prune stale decisions:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js prune
 ```
 
 ---

--- a/commands/release.md
+++ b/commands/release.md
@@ -189,6 +189,62 @@ NOTES
 
 ---
 
+### Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+Record the release decision:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'release' "$(cat <<'SUMMARY'
+Released v[version] on [date]. [N] commits. Bump: [patch|minor|major]
+SUMMARY
+)" "$(cat <<'DETAIL'
+[N] feat, [M] fix, [P] other commits since v[previous_version]
+DETAIL
+)"
+```
+
+Record the session:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update session [next_number] [test_count] "$(cat <<'EOF'
+Release v[version]: [N] commits, changelog updated, tagged
+EOF
+)"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+Record the release decision (releases are significant):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js decision 'release' "$(cat <<'SUMMARY'
+Released v[version] on [date]. [N] commits
+SUMMARY
+)" "$(cat <<'DETAIL'
+Bump: [patch|minor|major]. [N] feat, [M] fix since v[previous_version]
+DETAIL
+)"
+```
+
+Record session (auto-rotates to keep 5 most recent):
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js session [next_number] [test_count] "$(cat <<'EOF'
+Release v[version]
+EOF
+)"
+```
+
+Prune stale decisions:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js prune
+```
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/commands/remediate.md
+++ b/commands/remediate.md
@@ -346,7 +346,7 @@ All strategies output the same table:
 
 Write verification results back to tickets:
 - **GitHub:** Comment on each affected issue
-- **Postgres:** `node scripts/pipeline-db.js update finding [ID] status verified`
+- **Postgres:** `PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding [ID] status verified`
 
 If new findings are introduced: flag prominently. These may need another remediation pass.
 
@@ -369,14 +369,48 @@ If new findings are introduced: flag prominently. These may need another remedia
 | [ID] | [SEV] | [CAT] | [EFFORT] | [fixed/verified/remaining] | [#N/ID/—] | [SHA] |
 ```
 
-**If Postgres enabled:**
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
 ```bash
-node scripts/pipeline-db.js update decision '[SOURCE_TYPE]-remediation' 'Remediation [date]: [N] fixed, [M] verified, [P] remaining' '[summary]'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision "$(cat <<'TOPIC'
+[SOURCE_TYPE]-remediation
+TOPIC
+)" "$(cat <<'SUMMARY'
+Remediation [date]: [N] fixed, [M] verified, [P] remaining
+SUMMARY
+)" "$(cat <<'DETAIL'
+[summary]
+DETAIL
+)"
 ```
 
-For remaining or new findings, store as gotchas:
+For remaining or new HIGH/CRITICAL findings, store as gotchas:
 ```bash
-node scripts/pipeline-db.js update gotcha new '[ID]: [brief]' '[why unfixed or what to watch for]'
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update gotcha new "$(cat <<'TITLE'
+[ID]: [brief]
+TITLE
+)" "$(cat <<'RULE'
+[why unfixed or what to watch for]
+RULE
+)"
+```
+
+**If `knowledge.tier` is `"files"`:**
+
+For remaining or new HIGH/CRITICAL findings only:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-files.js gotcha "$(cat <<'TITLE'
+[ID]: [brief]
+TITLE
+)" "$(cat <<'RULE'
+[why unfixed or what to watch for]
+RULE
+)"
 ```
 
 ---

--- a/commands/review.md
+++ b/commands/review.md
@@ -180,6 +180,38 @@ Then: "Run `/pipeline:remediate --source review` to batch-fix 🔴 findings, or 
 
 ---
 
+### Step 8c — Persist to knowledge tier
+
+**Resolve `$SCRIPTS_DIR`:** Locate the pipeline plugin's `scripts/` directory:
+1. If `$PIPELINE_DIR` is set: `$PIPELINE_DIR/scripts/`
+2. Check `${HOME:-$USERPROFILE}/dev/pipeline/scripts/`
+3. Search: find `pipeline-db.js` under `${HOME:-$USERPROFILE}/.claude/`
+
+**If `knowledge.tier` is `"postgres"` AND `integrations.postgres.enabled`:**
+
+For each 🔴 or 🟡 finding, persist as a structured record:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update finding new "$(cat <<'EOF'
+{"id":"[FINDING_ID]","source":"review","severity":"[high|medium]","confidence":"[HIGH|MEDIUM|LOW]","location":"[file:line]","category":"[review criterion]","description":"[one-line description]","impact":"[why it matters]","remediation":"[fix description]","effort":"[quick|medium|large]"}
+EOF
+)"
+```
+
+Record the verdict:
+```bash
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update decision 'code-review' "$(cat <<'SUMMARY'
+Review [date]: [verdict]. [N] findings ([M] 🔴 / [P] 🟡 / [Q] 🔵)
+SUMMARY
+)" "$(cat <<'DETAIL'
+Files reviewed: [file list]. [1-sentence quality summary]
+DETAIL
+)"
+```
+
+**If `knowledge.tier` is `"files"`:** No additional writes — findings already saved to `docs/findings/review-*.md` above.
+
+---
+
 ### Dashboard Regeneration
 
 If `dashboard.enabled` is true in pipeline.yml (or `docs/dashboard.html` already exists):

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -305,9 +305,9 @@ The generated HTML is a self-contained file with no external dependencies. It in
 |-------|---------|-------------|
 | `tier` | `"files"` or `"postgres"` | Where session history, decisions, and gotchas are stored |
 
-**Files tier** (default) — zero setup. Creates `docs/sessions/*.md`, `DECISIONS.md`, `docs/gotchas.md`. No search capability. Good for small projects or quick setups.
+**Files tier** (default) — zero setup. Creates `docs/sessions/*.md`, `DECISIONS.md`, `docs/gotchas.md`. No search capability. Size-bounded to prevent context bloat (see [auto-persistence](#auto-persistence) below). Good for small projects or quick setups.
 
-**Postgres tier** — requires local PostgreSQL. Each project gets its own database (`pipeline_<project_name>`). Gives you:
+**Postgres tier** — requires local PostgreSQL. Each project gets its own database (`pipeline_<project_name>`). Full history, semantically searchable. Gives you:
 - Semantic search across all past sessions (requires [Ollama](https://ollama.com) running locally with any embedding model — no API keys, no cloud)
 - Keyword search across code index (works without Ollama)
 - Structured task tracking with status (pending/in_progress/done/deferred)
@@ -396,6 +396,32 @@ All profiles get the base checks (database access control, input sanitization, n
 | Mobile, Mobile + Web | Secure storage — never store tokens in plain storage |
 | API | Rate limiting, authentication, input schema validation |
 | Library | Boundary type validation — never trust caller input |
+
+---
+
+## Auto-Persistence
+
+Knowledge tier persistence is automatic. Every state-changing command silently persists its outputs — sessions, decisions, findings, gotchas, and task statuses — to whichever tier is configured. You never need to call `/pipeline:knowledge` manually.
+
+### Postgres tier — full history
+
+All data is persisted: sessions, decisions, gotchas, findings (structured JSON), and task statuses. Everything is queryable via `/pipeline:knowledge search` and semantically searchable via `/pipeline:knowledge hybrid` (requires Ollama).
+
+### Files tier — size-bounded active working set
+
+Markdown files get loaded into agent context wholesale, so the files tier is selective to prevent context bloat:
+
+| Data Type | Limit | Mechanism |
+|-----------|-------|-----------|
+| **Sessions** | Last 5 only | `pipeline-files.js` auto-rotates `docs/sessions/`, deleting older files |
+| **Decisions** | Locked + last 7 days | `pipeline-files.js prune` archives stale unlocked decisions to `docs/archive/` |
+| **Gotchas** | HIGH/CRITICAL only | Commands only write high-severity gotchas to files tier |
+| **Findings** | Already in `docs/findings/` | No additional files-tier write — findings files are read on-demand |
+| **Tasks** | Already in plan files | No additional files-tier write — plan files are the canonical task list |
+
+**Key principle:** The files tier is the active working set, not the full history. Locked decisions are constraints. Recent decisions are context. Everything else is either in postgres or derivable from git log.
+
+See the [command reference](reference.md#auto-persistence) for exactly what each command persists per tier.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -522,3 +522,29 @@ Modify config after initial setup.
 Session tracking, decisions, gotchas, and search.
 
 See the [configuration guide](guide.md#knowledge-tiers) for setup and all subcommands.
+
+---
+
+## Auto-Persistence
+
+Every state-changing command automatically persists its outputs to the configured knowledge tier. You never need to call `/pipeline:knowledge` manually — data flows silently as commands run.
+
+**What gets persisted per command:**
+
+| Command | Postgres Tier | Files Tier |
+|---------|--------------|------------|
+| `/pipeline:commit` | Decision (commit SHA + summary) | Nothing — too frequent |
+| `/pipeline:review` | Findings + verdict decision | Nothing — findings in `docs/findings/` |
+| `/pipeline:audit` | Findings + verdict decision | Decision only (audit verdicts are significant) |
+| `/pipeline:build` | Session + task status updates | Session (rotated) |
+| `/pipeline:debug` | Gotcha + decision | Gotcha only (root causes are always worth recording) |
+| `/pipeline:brainstorm` | Decision | Decision (only if locked) |
+| `/pipeline:plan` | Tasks + planning decision | Nothing — tasks are in the plan file |
+| `/pipeline:release` | Decision + session | Decision + session (rotated) |
+| `/pipeline:finish` | Session + decision | Session (rotated) + decision (if locked) |
+| `/pipeline:redteam` | Session + gotchas + decision | Gotchas (HIGH/CRITICAL only) + decision |
+| `/pipeline:remediate` | Decision + gotchas + finding status | Gotchas (HIGH only) |
+| `/pipeline:purpleteam` | Finding status + gotchas + decision | Gotchas (HIGH only) + decision |
+| `/pipeline:markdown-review` | Findings + decision | Nothing — findings in `docs/findings/` |
+
+**If neither tier is configured**, the persistence block is a no-op. Commands still write their reports to `docs/findings/` as normal.

--- a/scripts/pipeline-files.js
+++ b/scripts/pipeline-files.js
@@ -10,6 +10,7 @@
  *   node pipeline-files.js session <N> <tests> "<desc>"            # Record session N
  *   node pipeline-files.js gotcha "<issue>" "<rule>"               # Append a gotcha
  *   node pipeline-files.js decision "<topic>" "<decision>" "<reason>"  # Record a decision
+ *   node pipeline-files.js prune                                      # Archive stale decisions, rotate sessions
  */
 
 const fs = require('fs');
@@ -20,6 +21,10 @@ const ROOT = findProjectRoot();
 const SESSIONS_DIR = path.join(ROOT, 'docs', 'sessions');
 const GOTCHAS_PATH = path.join(ROOT, 'docs', 'gotchas.md');
 const DECISIONS_PATH = path.join(ROOT, 'DECISIONS.md');
+const ARCHIVE_DIR = path.join(ROOT, 'docs', 'archive');
+
+const MAX_SESSIONS = 5;
+const DECISION_RETAIN_DAYS = 7;
 
 // ─── HELPERS ──────────────────────────────────────────────────────────────────
 
@@ -120,6 +125,18 @@ function cmdSession(num, tests, desc) {
 
   fs.writeFileSync(filepath, content, 'utf8');
   console.log(c.green('Session recorded: ') + filepath);
+
+  // Rotate: keep only the most recent MAX_SESSIONS files
+  const allSessions = fs.readdirSync(SESSIONS_DIR)
+    .filter(f => f.endsWith('.md'))
+    .sort();
+  if (allSessions.length > MAX_SESSIONS) {
+    const toDelete = allSessions.slice(0, allSessions.length - MAX_SESSIONS);
+    for (const old of toDelete) {
+      fs.unlinkSync(path.join(SESSIONS_DIR, old));
+    }
+    console.log(c.dim(`Rotated: removed ${toDelete.length} old session(s), keeping ${MAX_SESSIONS}`));
+  }
 }
 
 // ─── GOTCHA ───────────────────────────────────────────────────────────────────
@@ -158,6 +175,67 @@ function cmdDecision(topic, decision, reason) {
   console.log(c.green('Decision recorded: ') + topic);
 }
 
+// ─── PRUNE ────────────────────────────────────────────────────────────────────
+
+function cmdPrune() {
+  let pruned = 0;
+
+  // Prune decisions: keep [LOCKED] + last DECISION_RETAIN_DAYS days
+  if (fs.existsSync(DECISIONS_PATH)) {
+    const content = fs.readFileSync(DECISIONS_PATH, 'utf8');
+    const header = '# Decisions\n\n';
+    const entries = content.replace(/^# Decisions\s*\n*/, '').split('---').filter(s => s.trim());
+
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - DECISION_RETAIN_DAYS);
+    const cutoffStr = cutoff.toISOString().slice(0, 10);
+
+    const keep = [];
+    const archive = [];
+
+    for (const entry of entries) {
+      const trimmed = entry.trim();
+      if (!trimmed) continue;
+
+      const isLocked = trimmed.includes('[LOCKED]');
+      const dateMatch = trimmed.match(/\*\*Date:\*\*\s*(\d{4}-\d{2}-\d{2})/);
+      const entryDate = dateMatch ? dateMatch[1] : null;
+
+      if (isLocked || (entryDate && entryDate >= cutoffStr)) {
+        keep.push(trimmed);
+      } else {
+        archive.push(trimmed);
+        pruned++;
+      }
+    }
+
+    // Archive old decisions
+    if (archive.length > 0) {
+      ensureDir(ARCHIVE_DIR);
+      const archivePath = path.join(ARCHIVE_DIR, `decisions-${today()}.md`);
+      const archiveContent = archive.map(e => `${e}\n\n---\n`).join('\n');
+
+      if (fs.existsSync(archivePath)) {
+        fs.appendFileSync(archivePath, '\n' + archiveContent, 'utf8');
+      } else {
+        fs.writeFileSync(archivePath, `# Archived Decisions — ${today()}\n\n${archiveContent}`, 'utf8');
+      }
+    }
+
+    // Rewrite DECISIONS.md with only kept entries
+    const kept = keep.length > 0
+      ? header + keep.map(e => `${e}\n\n---\n`).join('\n')
+      : header;
+    fs.writeFileSync(DECISIONS_PATH, kept, 'utf8');
+  }
+
+  if (pruned > 0) {
+    console.log(c.green(`Pruned: ${pruned} stale decision(s) archived to docs/archive/`));
+  } else {
+    console.log(c.dim('Nothing to prune.'));
+  }
+}
+
 // ─── HELP ─────────────────────────────────────────────────────────────────────
 
 function cmdHelp() {
@@ -169,6 +247,7 @@ ${c.cyan('Commands:')}
   ${c.bold('session')} <N> <tests> "<desc>"              Record session N
   ${c.bold('gotcha')} "<issue>" "<rule>"                  Add a critical constraint
   ${c.bold('decision')} "<topic>" "<decision>" "<reason>" Record an architectural decision
+  ${c.bold('prune')}                                     Archive stale decisions, rotate sessions
   ${c.bold('help')}                                      Show this message
 
 ${c.cyan('Storage:')}
@@ -196,6 +275,9 @@ const [, , cmd, ...args] = process.argv;
         break;
       case 'decision':
         cmdDecision(args[0], args[1], args[2]);
+        break;
+      case 'prune':
+        cmdPrune();
         break;
       case 'help':
       case undefined:


### PR DESCRIPTION
## Summary

- Every state-changing command now silently persists outputs to the configured knowledge tier — users never need to call `/pipeline:knowledge` manually
- Postgres tier gets full history (sessions, decisions, findings, gotchas, task statuses)
- Files tier is size-bounded to prevent context bloat: sessions capped at 5, decisions pruned to locked + 7 days, gotchas limited to HIGH/CRITICAL
- Fixed script paths in 3 existing commands (bare `node scripts/` → resolved `$SCRIPTS_DIR` with `PROJECT_ROOT`)
- Added persistence blocks to 10 remaining commands
- Added session rotation and decision pruning to `pipeline-files.js`
- Documented auto-persistence in `docs/reference.md` and `docs/guide.md`

## Test plan

- [x] `claude plugin validate .` passes
- [ ] Each command file has a "Persist to knowledge tier" section with both tier paths
- [ ] All persistence blocks use resolved script paths (not bare `node scripts/`)
- [ ] All multi-line content uses single-quoted heredocs
- [ ] Persistence blocks appear BEFORE dashboard regen blocks
- [ ] Run a command with `knowledge.tier: "postgres"` → data appears in `pipeline-db.js status`
- [ ] Run `pipeline-files.js prune` → stale decisions archived, locked retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)