### PR TITLE
feat: platform abstraction layer — platform.js + gh migration + Azure DevOps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ Pipeline tracks work across three stores. **Postgres is the master.** Always que
 | Store | Role | How to Read |
 |-------|------|-------------|
 | **Postgres** | Master source of truth | `PROJECT_ROOT=$(pwd) node scripts/pipeline-db.js query "SELECT * FROM roadmap_tasks"` |
-| **GitHub Issues** | Synced mirror (agent comms + human tracking) | `gh issue list --repo djwmobley/pipeline --label roadmap --state open` |
+| **GitHub Issues** | Synced mirror (agent comms + human tracking) | `node scripts/platform.js issue list --labels roadmap --state open` |
 | **README roadmap** | Rendered view (auto-generated from Postgres by dashboard) | Read `## Roadmap` section in README.md |
 
 **To find the next roadmap item:** Query `SELECT * FROM roadmap_tasks WHERE status = 'pending' ORDER BY id LIMIT 1`. The lowest-id pending item is next.

--- a/commands/architect.md
+++ b/commands/architect.md
@@ -194,7 +194,7 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 1. Find epic number from the spec file (`github_epic: N`).
 2. Comment on the epic with the decisions summary table:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Architectural Decisions
 
    | # | Domain | Decision | Confidence |
@@ -203,16 +203,11 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 
    Architecture saved to `docs/architecture.md`
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 3. For each LOW-confidence decision, create a child issue:
    ```bash
-   gh issue create --repo '[project.repo]' \
-     --title "$(cat <<'TITLE'
-   [DECISION-NNN]: [title] (needs review)
-   TITLE
-   )" \
-     --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title '[DECISION-NNN]: [title] (needs review)' --labels 'pipeline:decision' --stdin
    ## Architectural Decision — Needs Review
 
    **Domain:** [domain]
@@ -222,9 +217,8 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 
    Linked to: #[EPIC_N]
    EOF
-   )" \
-     --label "pipeline:decision"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 4. If no epic found in spec: skip linking.
 
 ---

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -102,12 +102,7 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 
 1. Create the feature epic:
    ```bash
-   gh issue create --repo '[project.repo]' \
-     --title "$(cat <<'TITLE'
-   [Feature name from spec title]
-   TITLE
-   )" \
-     --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title '[Feature name from spec title]' --labels 'pipeline:epic' --stdin
    ## Feature Epic
 
    [2-3 sentence summary from spec]
@@ -123,9 +118,8 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
    - [ ] Review
    - [ ] Ship
    EOF
-   )" \
-     --label "pipeline:epic"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 
 2. Store the returned issue number.
 3. Append `github_epic: [N]` to the spec file metadata (add after the first `---` line if YAML frontmatter exists, or add a metadata comment block at the top).
@@ -147,7 +141,7 @@ Using the same `SCRIPTS_DIR` resolved earlier for the locked-decisions query:
 
 Create a task linked to the epic:
 ```bash
-PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task new '[feature name]' 'design' [github_issue_number]
+PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task new '[feature name]' 'design' [issue_ref_number]
 ```
 
 **Case 2 — GitHub is NOT enabled but Postgres IS (no issue number):**

--- a/commands/build.md
+++ b/commands/build.md
@@ -88,21 +88,21 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 1. Read the plan file for `github_epic: N` in its metadata.
 2. If found, comment at build start:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Build Started
    **Tasks:** [count] | **Baseline:** [BASELINE_SHA]
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 3. At build completion (before presenting completion options), comment:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Build Complete
    **Tasks executed:** [count]
    **Auto-verify:** [PASS/FAIL/SKIPPED]
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
    Update the epic status checklist (edit the issue body to check `Build`).
 4. If no epic found: skip — build works without GitHub tracking.
 
@@ -230,7 +230,7 @@ PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task [task_id] defe
 2. Query for a parent roadmap task:
    ```bash
    PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js query "$(cat <<'SQL'
-   SELECT * FROM tasks WHERE github_issue = [N] AND category = 'roadmap'
+   SELECT * FROM tasks WHERE issue_ref = [N] AND category = 'roadmap'
    SQL
    )"
    ```

--- a/commands/compliance.md
+++ b/commands/compliance.md
@@ -316,18 +316,13 @@ Find the epic number: check the most recent spec or plan file for `github_epic: 
 For each **Tier 1** control family that is within automated scope but has **no mapped findings** (from the scope analysis), create an issue to expand red team coverage:
 
 ```bash
-gh issue list --repo '[project.repo]' --search 'compliance coverage gap [CONTROL_FAMILY] in:title' --state open --json number --limit 1
+node '[SCRIPTS_DIR]/platform.js' issue search 'compliance coverage gap [CONTROL_FAMILY] in:title' --state open --limit 1
 ```
 
 If an issue already exists, skip. Otherwise:
 
 ```bash
-gh issue create --repo '[project.repo]' \
-  --title "$(cat <<'TITLE'
-Compliance coverage gap: [FRAMEWORK_ID] [CONTROL_FAMILY]
-TITLE
-)" \
-  --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title 'Compliance coverage gap: [FRAMEWORK_ID] [CONTROL_FAMILY]' --labels 'compliance,coverage-gap' --stdin
 ## Coverage Gap
 
 **Framework:** [FRAMEWORK_NAME] (Tier [TIER])
@@ -346,13 +341,12 @@ these controls.
 
 Linked to: #[EPIC_N]
 EOF
-)" \
-  --label "compliance" --label "coverage-gap"
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 Comment the summary on the epic:
 ```bash
-gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
 ## Compliance Mapping Complete
 
 **Frameworks assessed:** [FRAMEWORK_COUNT]
@@ -362,8 +356,8 @@ gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
 **Per-framework summary:**
 [one line per framework: name, tier, MAPPED/RELATED/OUTSIDE_SCOPE counts]
 EOF
-)"
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 If no epic found: skip — compliance mapping works without GitHub tracking.
 

--- a/commands/debate.md
+++ b/commands/debate.md
@@ -198,7 +198,7 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 1. Read `github_epic: N` from the spec file's YAML frontmatter (same spec being debated).
 2. If found, post a summary comment on the epic:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Design Debate
 
    **Disposition:** [proceed / proceed-with-constraints / rethink]
@@ -209,8 +209,8 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 
    Verdict: `[path to verdict file]`
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 3. If no `github_epic` found in spec, skip — not all specs are tied to an epic.
 
 ---

--- a/commands/finish.md
+++ b/commands/finish.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git*), Bash(cd*), Bash(npx*), Bash(npm*), Bash(cargo*), Bash(go*), Bash(gh*)
+allowed-tools: Bash(git*), Bash(cd*), Bash(npx*), Bash(npm*), Bash(cargo*), Bash(go*), Bash(node*), Bash(cat*)
 description: Branch completion workflow — verify tests, present options, execute choice, clean up
 ---
 
@@ -74,19 +74,23 @@ Which option? (default: 1)
 
 <!-- checkpoint:MUST finish-merge-verify -->
 
-If a PR exists for the feature branch, merge via `gh pr merge` to preserve the audit trail:
+If a PR exists for the feature branch, merge via `platform.js pr merge` to preserve the audit trail:
 
 ```bash
 # Check if PR exists
-gh pr view [feature-branch] --repo '[project.repo]' --json number,state -q '.number' 2>/dev/null
+node '[SCRIPTS_DIR]/platform.js' pr view [feature-branch] 2>/dev/null
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 If a PR exists:
 ```bash
-gh pr merge [PR_NUMBER] --repo '[project.repo]' --squash --delete-branch
+node '[SCRIPTS_DIR]/platform.js' pr merge [PR_NUMBER] --squash --delete-branch
 git checkout [base-branch]
 git pull
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 If NO PR exists, fall back to local merge:
 ```bash
@@ -131,10 +135,7 @@ Before creating the PR, check the most recent plan file in `docs.plans_dir` for 
 
 ```bash
 git push -u origin [feature-branch]
-gh pr create --title "$(cat <<'TITLE'
-[title]
-TITLE
-)" --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' pr create --title '[title]' --stdin
 ## Summary
 [2-3 bullets]
 
@@ -143,8 +144,9 @@ TITLE
 
 [If epic found: Part of #[EPIC_N]]
 EOF
-)"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 Then cleanup worktree (Step 5).
 
 **Option 4: Keep as-is**
@@ -209,7 +211,7 @@ SQL
 
 Compile into a single comment and post to the epic:
 ```bash
-gh issue comment '[EPIC_N]' --repo '[project.repo]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment '[EPIC_N]' --stdin
 ## Ship Summary
 
 ### Review
@@ -229,8 +231,9 @@ gh issue comment '[EPIC_N]' --repo '[project.repo]' --body "$(cat <<'EOF'
 
 **Merged:** [SHA] → [base-branch]
 EOF
-)"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 This is the ONLY comment posted to the epic by any command. All phase-level
 detail lives on task issues. The epic summary is a compiled bird's-eye view.
@@ -247,7 +250,7 @@ detail lives on task issues. The epic summary is a compiled bird's-eye view.
 2. Query Postgres for the roadmap task:
    ```bash
    PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js query "$(cat <<'SQL'
-   SELECT * FROM tasks WHERE github_issue = [N] AND category = 'roadmap'
+   SELECT * FROM tasks WHERE issue_ref = [N] AND category = 'roadmap'
    SQL
    )"
    ```
@@ -265,10 +268,12 @@ detail lives on task issues. The epic summary is a compiled bird's-eye view.
 PROJECT_ROOT=$(pwd) node [scripts_dir]/pipeline-db.js update task [id] done
 ```
 
-**Close GitHub issue** — only if `integrations.github.enabled` AND the task has a `github_issue` value:
+**Close issue** — only if `platform.issue_tracker` is not `none` AND the task has an `issue_ref` value:
 ```bash
-gh issue close [N] --repo '[project.repo]' --comment '## Shipped'
+node '[SCRIPTS_DIR]/platform.js' issue close [N] --comment '## Shipped'
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 **Report:**
 ```

--- a/commands/init.md
+++ b/commands/init.md
@@ -179,6 +179,99 @@ If no source directories were detected (greenfield), defer resolution to Step 5 
 
 ---
 
+### Step 1c — Platform detection
+
+Detect the code hosting and issue tracking platform from the git remote URL. This determines which CLI backend `scripts/platform.js` uses for all issue and PR operations.
+
+**Platform detection from git remote:**
+
+| Remote URL pattern | Platform |
+|-------------------|----------|
+| `github.com` | `github` |
+| `dev.azure.com` or `*.visualstudio.com` | `azure-devops` |
+| Other / none | Default to `github` if `gh` CLI authenticated, otherwise `none` |
+
+**If quick mode:** Detect from remote URL, apply defaults silently, log decision. Skip to Step 2.
+
+**If github detected:**
+
+Verify `gh` CLI is available and authenticated:
+```bash
+gh auth status 2>&1 | head -1
+```
+If not authenticated: "GitHub CLI not authenticated. Run: `gh auth login`"
+
+Set in pipeline.yml:
+```yaml
+platform:
+  code_host: "github"
+  issue_tracker: "github"
+```
+
+**If azure-devops detected:**
+
+1. Extract org and project from remote URL:
+   - `https://dev.azure.com/{org}/{project}/_git/{repo}` → org, project
+   - `https://{org}.visualstudio.com/{project}/_git/{repo}` → org, project
+
+2. Verify `az devops` CLI extension is available:
+```bash
+az extension show --name azure-devops --query version --output tsv 2>/dev/null
+```
+If not installed: "Azure CLI DevOps extension required. Install with: `az extension add --name azure-devops`"
+
+3. Verify authentication:
+```bash
+az account show --query name --output tsv 2>/dev/null
+```
+If not authenticated: "Azure authentication required. Run: `az login` or set `AZURE_DEVOPS_EXT_PAT` environment variable"
+
+4. Verify project access:
+```bash
+az devops project show --project '{project}' --org 'https://dev.azure.com/{org}' --query name --output tsv 2>/dev/null
+```
+If fails: "Azure DevOps access denied. Verify your PAT has Work Items (Read & Write) and Code (Read & Write) scopes."
+
+5. Detect process template:
+```bash
+az devops project show --project '{project}' --org 'https://dev.azure.com/{org}' --query 'capabilities.processTemplate.templateName' --output tsv
+```
+
+6. Resolve state names from process template:
+
+| Process Template | done_state | active_state |
+|-----------------|------------|-------------|
+| Basic | Done | Doing |
+| Agile | Closed | Active |
+| Scrum | Done | Committed |
+| CMMI | Closed | Active |
+
+7. Set defaults:
+```bash
+az devops configure --defaults organization='https://dev.azure.com/{org}' project='{project}'
+```
+
+8. Set in pipeline.yml:
+```yaml
+platform:
+  code_host: "azure-devops"
+  issue_tracker: "azure-devops"
+  azure_devops:
+    organization: "{org}"
+    project: "{project}"
+    process_template: "{detected}"
+    work_item_type: "Task"
+    done_state: "{resolved}"
+    active_state: "{resolved}"
+```
+
+**If no remote or unrecognized host:**
+
+Set both to `none`. Issue tracking and PR operations will be skipped. Warn the user:
+> "No recognized platform detected. Issue tracking and PR workflows will be disabled. Add a git remote and re-run `/pipeline:init` to enable."
+
+---
+
 ### Step 2 — Project profile
 
 **If quick mode:** Use the inferred profile directly without asking for confirmation. If established project, apply the signal table below and pick the best match. If greenfield (no signals), default to `fullstack`. Skip stack recommendations entirely. Log the chosen profile and evidence (e.g., "Profile: fullstack — detected next.config.ts"). Skip to Step 2b.
@@ -736,29 +829,26 @@ If yes, resolve the plugin's install location by finding the directory containin
 
 ---
 
-### GitHub Issue Tracking
+### Issue Tracking
 
-If `project.repo` is set (GitHub is enabled), create a GitHub issue to track that initialization was completed:
+If `platform.issue_tracker` is not `none`, create an issue to track that initialization was completed:
 
-First ensure the label exists (no-op if it already does):
+Create the initialization issue:
 ```bash
-gh label create pipeline --description 'Pipeline tracking' --color 0E8A16 --repo '[GITHUB_REPO]' 2>/dev/null || true
-```
-
-Then create the issue:
-```bash
-gh issue create --repo '[GITHUB_REPO]' --title 'Pipeline initialized' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title 'Pipeline initialized' --labels 'pipeline' --stdin
 ## Pipeline Setup
 
 **Profile:** [profile]
 **Knowledge tier:** [tier]
 **Security policy:** [policy]
 **Engagement:** [engagement style]
+**Platform:** [code_host] / [issue_tracker]
 **Integrations:** [list enabled]
 
 Config: `.claude/pipeline.yml`
 EOF
-)" --label "pipeline"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 This is the first entry in the project's issue trail. All subsequent pipeline commands post to their own issues, building the project's audit log.

--- a/commands/lint-agents.md
+++ b/commands/lint-agents.md
@@ -71,7 +71,7 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
 Check the most recent plan file in `docs.plans_dir` for `github_epic: N`. If found, post a summary comment:
 
 ```bash
-gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
 ## Agent Template Lint
 
 **Templates scanned:** [count]
@@ -80,8 +80,8 @@ gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
 
 [If findings: top 3 findings listed]
 EOF
-)"
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 ---
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -218,15 +218,15 @@ If `integrations.github.enabled` AND `integrations.github.issue_tracking`:
    - Write `github_epic: [N]` into the plan file metadata (add after the first `---` line).
    - Comment on the epic:
      ```bash
-     gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+     cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
      ## Plan Created
 
      **Tasks:** [count]
      **Plan:** `[plan file path]`
      [bulleted task title list]
      EOF
-     )"
      ```
+     If the command fails, notify the user with the error and ask for guidance.
    - Update the epic status checklist (edit the issue body to check `Plan`).
 3. If not found: skip — user may have started from plan directly or GitHub tracking was added after brainstorm.
 

--- a/commands/purpleteam.md
+++ b/commands/purpleteam.md
@@ -71,10 +71,11 @@ If `knowledge.tier` is `"files"`:
 
 Store results as `KNOWLEDGE_CONTEXT`.
 
-If GitHub enabled, fetch issue state:
+If `platform.issue_tracker` is not `none`, fetch issue state:
 ```bash
-gh issue list --repo '[project.repo]' --label 'redteam' --state all --json number,title,state,labels --limit 100
+node '[SCRIPTS_DIR]/platform.js' issue list --labels 'redteam' --state all --limit 100
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 **Present the assessment plan:**
 
@@ -212,7 +213,7 @@ mkdir -p docs/findings
 
 For each VERIFIED finding that has a GitHub issue number:
 ```bash
-gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
 ## Purple Team Verification: VERIFIED
 
 Attack vector confirmed closed.
@@ -221,17 +222,19 @@ Attack vector confirmed closed.
 **Confidence:** [confidence level from verifier result]
 **Defensive rule:** [defensive pattern extracted for this finding]
 EOF
-)"
 ```
+If the command fails, notify the user with the error and ask for guidance.
+
 Close the issue if not already closed:
 ```bash
-gh issue close [N] --repo '[project.repo]' 2>/dev/null
+node '[SCRIPTS_DIR]/platform.js' issue close [N] 2>/dev/null
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 For each REGRESSION finding that has a GitHub issue number:
 ```bash
-gh issue reopen [N] --repo '[project.repo]' 2>/dev/null
-gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+node '[SCRIPTS_DIR]/platform.js' issue reopen [N] 2>/dev/null
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
 ## Purple Team Verification: REGRESSION
 
 Fix introduced a regression.
@@ -242,13 +245,13 @@ Fix introduced a regression.
 
 Requires additional remediation.
 EOF
-)"
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 For each INCOMPLETE finding that has a GitHub issue number:
 ```bash
-gh issue reopen [N] --repo '[project.repo]' 2>/dev/null
-gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+node '[SCRIPTS_DIR]/platform.js' issue reopen [N] 2>/dev/null
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
 ## Purple Team Verification: INCOMPLETE
 
 Code was changed but the exploitation scenario was not fully closed.
@@ -258,8 +261,8 @@ Code was changed but the exploitation scenario was not fully closed.
 
 Requires additional remediation.
 EOF
-)"
 ```
+If the command fails, notify the user with the error and ask for guidance.
 
 **Shell safety:** All comment bodies use heredocs with single-quoted delimiters (`<<'EOF'`) to prevent injection from report-derived content.
 

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -232,7 +232,7 @@ Find the epic number: read the spec or plan file for `github_epic: N`.
 **Plan mode:**
 - Comment on the epic that a test plan was created:
   ```bash
-  gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+  cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
   ## QA Test Plan Created
 
   **Work packages:** [count]
@@ -241,19 +241,14 @@ Find the epic number: read the spec or plan file for `github_epic: N`.
 
   Plan: `[test plan file path]`
   EOF
-  )"
   ```
+  If the command fails, notify the user with the error and ask for guidance.
 - Update the epic status checklist (check `QA`).
 
 **Verify mode:**
 1. For each blocking FAIL where triage = code-is-wrong:
    ```bash
-   gh issue create --repo '[project.repo]' \
-     --title "$(cat <<'TITLE'
-   QA: [scenario ID] — [description]
-   TITLE
-   )" \
-     --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title 'QA: [scenario ID] — [description]' --labels 'pipeline:qa' --stdin
    ## QA Failure
 
    **Scenario:** [scenario ID]
@@ -263,9 +258,8 @@ Find the epic number: read the spec or plan file for `github_epic: N`.
 
    Linked to: #[EPIC_N]
    EOF
-   )" \
-     --label "pipeline:qa"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 2. Comment the verdict summary on the epic.
 
 If no epic found: skip — QA works without GitHub tracking.

--- a/commands/redteam.md
+++ b/commands/redteam.md
@@ -414,16 +414,11 @@ Find the epic number: check the most recent spec or plan file for `github_epic: 
 
 1. For each CRITICAL or HIGH finding, check for existing issue first:
    ```bash
-   gh issue list --repo '[project.repo]' --search '[FINDING_ID] in:title' --state open --json number --limit 1
+   node '[SCRIPTS_DIR]/platform.js' issue search '[FINDING_ID] in:title' --state open --limit 1
    ```
    If an issue already exists for this finding ID, skip creation. Otherwise:
    ```bash
-   gh issue create --repo '[project.repo]' \
-     --title "$(cat <<'TITLE'
-   [FINDING_ID]: [brief summary]
-   TITLE
-   )" \
-     --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title '[FINDING_ID]: [brief summary]' --labels 'redteam,[severity]' --stdin
    ## Security Finding
 
    **Severity:** [CRITICAL/HIGH]
@@ -436,19 +431,18 @@ Find the epic number: check the most recent spec or plan file for `github_epic: 
 
    Linked to: #[EPIC_N]
    EOF
-   )" \
-     --label "redteam" --label "[severity]"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 2. Comment the summary on the epic:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Red Team Assessment Complete
 
    **Findings:** [C] critical, [H] high, [M] medium, [L] low
    **Report:** `[report file path]`
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 
 MEDIUM and LOW findings do NOT get issues — they stay in `docs/findings/` only.
 

--- a/commands/remediate.md
+++ b/commands/remediate.md
@@ -100,18 +100,13 @@ For each finding where `CREATE_ISSUE` is true:
 
 **Dedup check:** Before creating a new issue, search for an existing one with the same finding ID:
 ```bash
-gh issue list --repo '[project.repo]' --search '[FINDING_ID] in:title' --state open --json number --limit 1
+node '[SCRIPTS_DIR]/platform.js' issue search '[FINDING_ID] in:title' --state open --limit 1
 ```
-If found: reuse that issue number instead of creating a duplicate. Skip the `gh issue create` below.
+If found: reuse that issue number instead of creating a duplicate. Skip the `issue create` below.
 
 If not found, create:
 ```bash
-gh issue create --repo '[project.repo]' \
-  --title "$(cat <<'TITLE'
-[ID]: [one-line description]
-TITLE
-)" \
-  --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title '[ID]: [one-line description]' --labels '[SOURCE_TYPE],[severity-lowercase]' --stdin
 ## Finding
 
 **ID:** [ID]
@@ -133,9 +128,9 @@ TITLE
 ### Source Report
 `[report path]`
 EOF
-)" \
-  --label "[SOURCE_TYPE]" --label "[severity-lowercase]"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 Store: `finding_id → issue_number`.
 
@@ -149,7 +144,7 @@ node scripts/pipeline-db.js update finding new '{"id":"[ID]","source":"[SOURCE_T
 
 If a GitHub issue was also created, link it:
 ```bash
-node scripts/pipeline-db.js update finding [ID] github_issue [N]
+node scripts/pipeline-db.js update finding [ID] issue_ref [N]
 ```
 
 #### If files only (no GitHub, no Postgres)
@@ -235,7 +230,7 @@ Prepare the `{{TICKET_CONTEXT}}` substitution based on backend:
   ## Finding Context
 
   Read the GitHub issue for full requirements:
-  gh issue view [N] --repo '[repo]' --json title,body,labels,comments
+  node '[SCRIPTS_DIR]/platform.js' issue view [N]
 
   Affected files from LOCATION: [paths]
   ```
@@ -290,14 +285,14 @@ EOF
 
 - **GitHub:** Post comment and close:
   ```bash
-  gh issue comment [N] --repo '[repo]' --body "$(cat <<'EOF'
+  cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
   Fixed in [SHA].
 
   Changes: [brief summary of what was changed]
   EOF
-  )"
-  gh issue close [N] --repo '[repo]'
+  node '[SCRIPTS_DIR]/platform.js' issue close [N]
   ```
+  If the command fails, notify the user with the error and ask for guidance.
 
 - **Postgres:**
   ```bash
@@ -311,7 +306,7 @@ EOF
 
 Prepare `{{TICKET_CONTEXT}}` for reviewer based on backend:
 
-- **GitHub:** `"Read the GitHub issue for requirements: gh issue view [N] --repo '[repo]' --json title,body,labels,comments. Read the fix diff: git show [SHA]"`
+- **GitHub:** `"Read the GitHub issue for requirements: node '[SCRIPTS_DIR]/platform.js' issue view [N]. Read the fix diff: git show [SHA]"`
 - **Postgres:** `"Read the finding: node scripts/pipeline-db.js get finding [ID]. Read the fix diff: git show [SHA]"`
 - **Files (fallback):** Inline requirements from triage + include the diff
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(git*), Bash(cd*), Bash(npx*), Bash(npm*), Bash(cargo*), Bash(go*), Bash(semgrep*), Bash(command*), Read(*), Glob(*), Grep(*)
+allowed-tools: Bash(git*), Bash(cd*), Bash(npx*), Bash(npm*), Bash(cargo*), Bash(go*), Bash(semgrep*), Bash(command*), Bash(node*), Bash(cat*), Read(*), Glob(*), Grep(*)
 description: Per-change quality review — evaluates code quality with severity tiers and config-driven criteria
 ---
 
@@ -264,16 +264,11 @@ Find the epic number: check the most recent plan file in `docs.plans_dir` for `g
 
 1. For each 🔴 Must Fix finding, check for existing issue first:
    ```bash
-   gh issue list --repo '[project.repo]' --search '[FINDING_ID] in:title' --state open --json number --limit 1
+   node '[SCRIPTS_DIR]/platform.js' issue search '[FINDING_ID] in:title' --state open --limit 1
    ```
    If an issue already exists for this finding ID, skip creation. Otherwise:
    ```bash
-   gh issue create --repo '[project.repo]' \
-     --title "$(cat <<'TITLE'
-   [FINDING_ID]: [description]
-   TITLE
-   )" \
-     --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue create --title '[FINDING_ID]: [description]' --labels 'review,high' --stdin
    ## Code Review Finding
 
    **Severity:** 🔴 Must Fix
@@ -285,29 +280,29 @@ Find the epic number: check the most recent plan file in `docs.plans_dir` for `g
 
    Linked to: #[EPIC_N]
    EOF
-   )" \
-     --label "review" --label "high"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 2. Comment the verdict summary on the epic:
    ```bash
-   gh issue comment [N] --repo '[project.repo]' --body "$(cat <<'EOF'
+   cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [N] --stdin
    ## Code Review Verdict
 
    **Result:** [verdict]
    **Findings:** [M] 🔴 / [P] 🟡 / [Q] 🔵
    **Report:** `[report file path]`
    EOF
-   )"
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 
 🟡 and 🔵 findings do NOT get issues — they stay in `docs/findings/` only.
 
 3. Update the epic status checklist — read the current issue body, replace `- [ ] Review` with `- [x] Review`, and update the issue:
    ```bash
-   BODY=$(gh issue view [N] --repo '[project.repo]' --json body -q '.body')
-   UPDATED=$(echo "$BODY" | sed 's/- \[ \] Review/- [x] Review/')
-   gh issue edit [N] --repo '[project.repo]' --body "$UPDATED"
+   BODY=$(node '[SCRIPTS_DIR]/platform.js' issue view [N] | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).body")
+   UPDATED=$(printf '%s' "$BODY" | sed 's/- \[ \] Review/- [x] Review/')
+   printf '%s' "$UPDATED" | node '[SCRIPTS_DIR]/platform.js' issue edit [N] --stdin
    ```
+   If the command fails, notify the user with the error and ask for guidance.
 
 If no epic found: skip — review works without GitHub tracking.
 

--- a/docs/MANIFEST.md
+++ b/docs/MANIFEST.md
@@ -130,6 +130,18 @@ All three stores update automatically on merge. No manual intervention needed.
 | `scripts/package.json` | Update version field |
 | `README.md` | Move roadmap items from Open to Shipped |
 
+### Changing Platform Abstraction (issue tracking / code hosting)
+
+| Doc | What to Update |
+|-----|---------------|
+| `docs/guide.md` | Update platform config section, supported platforms table |
+| `docs/reference.md` | Update platform.js CLI reference |
+| `docs/workflow-reference.md` | Update three-store contract if operations change |
+| `docs/security.md` | Update credential management section (PAT scopes, storage) |
+| `docs/errors.md` | Add/update PLATFORM_TWO_STORE and platform auth errors |
+| `templates/pipeline.yml` | Update `platform` section defaults |
+| `scripts/platform.js` | Source of truth — docs must match code |
+
 ### Changing GitHub Integration Behavior
 
 | Doc | What to Update |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -203,7 +203,7 @@ Pipeline detects optional tools at init time. When a tool is missing or becomes 
 |------|-------------------------|-----------------|
 | PostgreSQL | Semantic search, structured task/finding tracking | Files tier: markdown sessions, decisions, gotchas. All commands run. |
 | Ollama | Vector similarity search (embeddings) | FTS keyword search via Postgres, or no search on files tier |
-| GitHub CLI (`gh`) | PR creation from `/pipeline:finish`, lifecycle issue tracking (epics, finding issues) | Push manually, create PRs in browser, no issue tracking |
+| Platform CLI (`gh` / `az`) | PR creation from `/pipeline:finish`, lifecycle issue tracking (epics, finding issues) | Push manually, create PRs in browser, no issue tracking. Set `platform.issue_tracker: none` to suppress. |
 | Playwright | Automated screenshots (secondary path) | Chrome DevTools MCP, or provide screenshots manually |
 | Stitch / Figma MCP | AI design mockups in brainstorm and UI review | HTML wireframes via visual companion |
 | Sentry | Auto-pull recent errors in `/pipeline:debug` | Describe errors manually when prompted |
@@ -244,15 +244,49 @@ If you changed embedding models, you may need to drop and recreate the embedding
 
 ---
 
-### GitHub CLI not authenticated
+### PLATFORM_TWO_STORE: Unsupported platform
+
+**Commands:** Any command that creates issues, PRs, or comments
+
+**Why:** `platform.code_host` or `platform.issue_tracker` in `pipeline.yml` is set to an unsupported value. Supported values: `github`, `azure-devops`, `none`.
+
+**Fix:** Edit `.claude/pipeline.yml` and set the platform fields to a supported value. Run `/pipeline:init` to re-detect from git remote URL.
+
+---
+
+### Platform CLI not authenticated
 
 **Commands:** `/pipeline:finish` (PR creation), any command with issue tracking enabled
 
-**Why:** `gh auth status` shows not logged in, or `GITHUB_TOKEN` is not set or expired.
+**Why:** The platform CLI is not authenticated:
+- **GitHub:** `gh auth status` shows not logged in, or `GITHUB_TOKEN` is not set
+- **Azure DevOps:** `az account show` fails, or `AZURE_DEVOPS_EXT_PAT` is not set
 
-**Fix:** Run `gh auth login` and follow the prompts. Or set `GITHUB_TOKEN` as an environment variable.
+**Fix:**
+- **GitHub:** Run `gh auth login` or set `GITHUB_TOKEN`
+- **Azure DevOps:** Run `az login` or set `AZURE_DEVOPS_EXT_PAT`
 
-To disable issue tracking while keeping other functionality, set `integrations.github.issue_tracking: false` in `pipeline.yml`.
+To disable issue tracking entirely, set `platform.issue_tracker: none` in `pipeline.yml`.
+
+---
+
+### Azure DevOps extension not installed
+
+**Commands:** Any command that uses Azure DevOps operations
+
+**Why:** The `azure-devops` extension for Azure CLI is not installed.
+
+**Fix:** Run `az extension add --name azure-devops`.
+
+---
+
+### Azure DevOps work item state transition failed
+
+**Commands:** `/pipeline:remediate` (close finding issue), `/pipeline:finish` (close epic)
+
+**Why:** The configured `done_state` is not a valid transition for the work item's current state. State names vary by process template (Basic, Agile, Scrum, CMMI).
+
+**Fix:** Check your process template with `az devops project show --project <project> --query 'capabilities.processTemplate.templateName'`. Verify the `platform.azure_devops.done_state` in `pipeline.yml` matches your template. See `docs/security.md` section 10 for the state mapping table.
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -310,7 +310,7 @@ Controls `/pipeline:remediate` — multi-source finding remediation. Accepts fin
 **Migration:** The old `verification_rerun: true` boolean is no longer supported. Replace with the `verification` object above.
 
 **Ticket backends (checked in priority order):**
-1. GitHub Issues — when `integrations.github.enabled`. The issue body IS the finding data. Agents read with `gh issue view`.
+1. Issue tracker — when `platform.issue_tracker` is not `none`. The issue body IS the finding data. Agents read with `node scripts/platform.js issue view`.
 2. Postgres findings table — when `knowledge.tier == "postgres"`. Agents read with `pipeline-db.js get finding`.
 3. Files — always available as fallback.
 
@@ -520,7 +520,7 @@ knowledge:
 | `/pipeline:knowledge hybrid "query"` | Keyword + vector search |
 | `/pipeline:knowledge index` | Update embeddings |
 | `/pipeline:knowledge query "SQL"` | Run raw SQL |
-| `/pipeline:knowledge task ID github_issue N` | Link task to GitHub issue |
+| `/pipeline:knowledge task ID issue_ref N` | Link task to issue/work-item |
 | `/pipeline:knowledge task ID readme_label "text"` | Set README roadmap display label |
 | `/pipeline:knowledge task ID category value` | Set category: roadmap, build, finding, internal |
 | `/pipeline:knowledge export` | Export gotchas + decisions to JSON |
@@ -583,6 +583,60 @@ All profiles get the base checks (database access control, input sanitization, n
 | Mobile, Mobile + Web | Secure storage — never store tokens in plain storage |
 | API | Rate limiting, authentication, input schema validation |
 | Library | Boundary type validation — never trust caller input |
+
+---
+
+## Platform Configuration
+
+Pipeline uses a platform abstraction layer (`scripts/platform.js`) for all issue tracking and PR operations. The platform is detected during init from your git remote URL.
+
+### Supported Platforms
+
+| Platform | CLI Tool | Issue Tracking | Code Hosting | Status |
+|----------|---------|---------------|-------------|--------|
+| GitHub | `gh` (official) | Yes | Yes | Shipped |
+| Azure DevOps | `az devops` + `az rest` | Yes (Work Items) | Yes (PRs) | Shipped |
+| GitLab | `glab` (official) | Yes | Yes (MRs) | Planned |
+| Jira | `jira-cli` (community) | Yes | No (pairs with code host) | Planned |
+
+### Platform Config
+
+```yaml
+platform:
+  code_host: "github"          # github, azure-devops, none
+  issue_tracker: "github"      # github, azure-devops, none
+  azure_devops:                # Only when azure-devops is detected
+    organization: "MyOrg"
+    project: "MyProject"
+    process_template: "Agile"  # Basic, Agile, Scrum, CMMI
+    work_item_type: "Task"
+    done_state: "Closed"       # Varies by process template
+    active_state: "Active"     # Varies by process template
+```
+
+### How Agents Use It
+
+Agents call `node scripts/platform.js` like any shell command. They never know which platform is underneath:
+
+```bash
+# Create an issue
+node scripts/platform.js issue create --title 'Fix bug' --labels 'pipeline'
+
+# Comment with long content via stdin
+cat <<'EOF' | node scripts/platform.js issue comment 42 --stdin
+## Findings
+...body content...
+EOF
+
+# Merge a PR
+node scripts/platform.js pr merge 42 --squash --delete-branch
+```
+
+All verification, retry logic, and auth validation happen inside `platform.js` in Node.js code — zero token cost to agents. The script either succeeds (ref on stdout, exit 0) or fails (error on stderr, exit 1).
+
+### Credential Setup
+
+See [Security — Platform Credential Management](security.md#10-platform-credential-management) for PAT scopes, storage methods, and CI/CD patterns.
 
 ---
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -393,7 +393,7 @@ All finding sources produce identical artifacts — same issue format, same comm
 - `--file path/to/file.md` — external report (QA, UX designer, etc.)
 
 **Ticket backends (checked in priority order):**
-1. **GitHub Issues** — when `integrations.github.enabled`. The issue body IS the ticket. Agents read with `gh issue view`.
+1. **Issue Tracker** — when `platform.issue_tracker` is not `none`. The issue body IS the ticket. Agents read with `node scripts/platform.js issue view`.
 2. **Postgres** — when `knowledge.tier == "postgres"`. Finding records in the `findings` table. Agents read with `pipeline-db.js get finding`.
 3. **Files** — always available as fallback. Inline context in prompts (only case where this is necessary).
 
@@ -701,6 +701,46 @@ See the [configuration guide](guide.md#knowledge-tiers) for setup and all subcom
 
 ---
 
+### `scripts/platform.js` — Platform Abstraction CLI
+
+Unified interface for issue tracking and code hosting operations. All agents call this instead of platform-specific CLIs.
+
+**Issue operations:**
+```bash
+node scripts/platform.js issue create --title "Title" --body "Body" --labels "label1,label2"
+node scripts/platform.js issue comment <ref> --stdin          # Read body from stdin
+node scripts/platform.js issue close <ref>
+node scripts/platform.js issue list --labels "pipeline" --state open
+node scripts/platform.js issue view <ref>
+node scripts/platform.js issue edit <ref> --stdin
+node scripts/platform.js issue reopen <ref>
+node scripts/platform.js issue search "query" --state open --limit 5
+```
+
+**PR operations:**
+```bash
+node scripts/platform.js pr create --title "Title" --source feat/x --target main --stdin
+node scripts/platform.js pr merge <ref> --squash --delete-branch
+node scripts/platform.js pr comment <ref> --stdin
+node scripts/platform.js pr diff <ref>
+node scripts/platform.js pr view <ref>
+```
+
+**Auth verification:**
+```bash
+node scripts/platform.js auth check
+```
+
+**Behavior:**
+- Reads platform config from `.claude/pipeline.yml` (`platform.*` section)
+- Dispatches to GitHub (`gh`) or Azure DevOps (`az`) backend transparently
+- All verification and retry (3 attempts, exponential backoff 2s/4s/8s) happens in Node.js code
+- Exit 0 with ref/data on stdout = success. Exit 1 with error on stderr = failure
+- Uses `execFile` (not `exec`) for shell safety — no injection via argument content
+- `--stdin` flag reads long-form content from stdin to avoid shell escaping issues
+
+---
+
 ## Auto-Persistence
 
 Every state-changing command automatically persists its outputs to the configured knowledge tier. You never need to call `/pipeline:knowledge` manually — data flows silently as commands run.
@@ -744,7 +784,7 @@ Pipeline maintains three tracking stores with a clear hierarchy:
 **`pipeline-db.js` task field updates:**
 
 ```
-update task <id> github_issue <N>     # Link task to GitHub issue
+update task <id> issue_ref <N>        # Link task to issue/work-item
 update task <id> readme_label "<text>" # Set README roadmap display label
 update task <id> category <value>     # roadmap | build | finding | internal
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -299,3 +299,38 @@ compliance:
 | After purple team | `/pipeline:compliance` | Map findings to regulatory controls |
 | Pre-release check | `/pipeline:redteam` then full loop | Final security sweep |
 | Dependency update | `/pipeline:purpleteam` | Check if new vulnerabilities appeared |
+
+---
+
+## 10. Platform Credential Management
+
+Pipeline interacts with external platforms (GitHub, Azure DevOps) for issue tracking and PR operations via `scripts/platform.js`. Credentials must never be stored in source code, `pipeline.yml`, or committed files.
+
+### Supported Credential Methods
+
+| Platform | Recommended | Environment Variable | Credential Store |
+|----------|------------|---------------------|-----------------|
+| GitHub | `gh auth login` (interactive, stores in OS keychain) | `GITHUB_TOKEN` | macOS Keychain, Windows Credential Manager, `gh` auth token store |
+| Azure DevOps | `az login` (interactive, Entra ID) | `AZURE_DEVOPS_EXT_PAT` | Azure CLI token cache (`~/.azure/`), Windows Credential Manager |
+
+### Required PAT Scopes
+
+| Platform | Required Scopes | Why |
+|----------|----------------|-----|
+| GitHub | `repo`, `project` | Issue CRUD, PR CRUD, repo access |
+| Azure DevOps | Work Items (Read & Write), Code (Read & Write), Pull Request Threads (Read & Write) | Work item CRUD, PR CRUD, thread comments via REST API |
+
+### Security Rules
+
+1. **Never log credentials** — `platform.js` never echoes tokens, PATs, or auth headers to stdout/stderr
+2. **Validate auth before first use** — on first call, the script verifies the CLI is authenticated (e.g., `gh auth status`, `az account show`). If not, it exits with a message directing the user to authenticate
+3. **Never store credentials in pipeline.yml** — the config stores platform names and settings, never tokens or secrets
+4. **Environment variables for CI/CD** — CI environments should set `GITHUB_TOKEN` or `AZURE_DEVOPS_EXT_PAT` as pipeline/workflow secrets, never as plaintext in config files
+
+### Team Sharing
+
+For teams where multiple developers use Pipeline on the same project:
+
+- **GitHub:** Each developer authenticates with their own `gh auth login`. Pipeline uses whoever is currently authenticated.
+- **Azure DevOps:** Each developer authenticates with `az login` (Entra ID) or sets their own PAT. Organization-level PATs can be used for shared service accounts but should be stored in a secrets manager, not shared via chat/email.
+- **CI/CD:** Use repository/pipeline secrets (`GITHUB_TOKEN` in GitHub Actions, `AZURE_DEVOPS_EXT_PAT` in Azure Pipelines). Never commit tokens to source.

--- a/docs/workflow-reference.md
+++ b/docs/workflow-reference.md
@@ -220,7 +220,7 @@ Preflight gate chain: review gate (hard stop on source file count) → typecheck
 | **Next** | deploy |
 | **On fail** | N/A (interactive — user resolves merge conflicts) |
 
-Merges PR via `gh pr merge`. Compiles single epic summary from Postgres (all phase results, 5K limit). Closes feature epic. Regenerates dashboard. Syncs README roadmap from Postgres.
+Merges PR via `platform.js pr merge`. Compiles single epic summary from Postgres (all phase results, 5K limit). Closes feature epic. Regenerates dashboard. Syncs README roadmap from Postgres.
 
 ### 13. Deploy (optional)
 
@@ -292,6 +292,19 @@ Every agent that produces output writes to all applicable stores. The orchestrat
 | Finish | Closes session, marks task done | Epic summary (compiled, 5K limit) | Cleanup | Compiles all phase results |
 | Deploy | N/A | N/A | Deploy status | Project-specific |
 
+### Platform Abstraction
+
+The "GitHub Issue" column above is platform-agnostic — it uses `scripts/platform.js` which routes to the configured backend (GitHub or Azure DevOps). The contract:
+
+| Interface | Operations | GitHub Backend | Azure DevOps Backend |
+|-----------|-----------|---------------|---------------------|
+| IssueTracker | create, comment, close, list, view, edit, reopen, search | `gh issue *` | `az boards work-item *` + WIQL |
+| CodeHost | create PR, merge PR, comment on PR, diff PR, view PR | `gh pr *` | `az repos pr *` + `az rest` (threads) |
+
+All verification (state transition succeeded, PR actually merged, issue ref returned) and retry logic (3 attempts, exponential backoff 2s/4s/8s) happens inside `platform.js` in Node.js code. Agents never parse platform responses or check status fields — they treat the command as pass/fail.
+
+---
+
 ## Orchestrator CLI Reference
 
 ```bash
@@ -342,4 +355,4 @@ PROJECT_ROOT=$(git rev-parse --show-toplevel) node '[SCRIPTS_DIR]/pipeline-conte
 - **Implementer, reviewer:** `decisions 10`, `gotchas` (via CLI). Also read `docs/architecture.md` and `.claude/build-state.json` directly as file reads.
 - **Dashboard:** `session` (via CLI)
 - **Debug/investigation:** `full` (via CLI)
-- Other agents read stores directly (e.g., `gh issue view`, `cat .claude/build-state.json`) rather than going through pipeline-context.js.
+- Other agents read stores directly (e.g., `node scripts/platform.js issue view`, `cat .claude/build-state.json`) rather than going through pipeline-context.js.

--- a/scripts/pipeline-context.js
+++ b/scripts/pipeline-context.js
@@ -37,12 +37,14 @@ const CONFIG = loadConfig();
 // ─── SHELL HELPERS ──────────────────────────────────────────────────────────
 
 /**
- * Run gh CLI with args array (no shell interpolation — safe from injection).
+ * Run platform.js with args array (no shell interpolation — safe from injection).
+ * Routes all issue/PR operations through the platform abstraction layer.
  * Returns stdout as string, or null on failure.
  */
-function gh(args) {
+function platform(args) {
+  const platformScript = path.join(__dirname, 'platform.js');
   try {
-    return execFileSync('gh', args, {
+    return execFileSync(process.execPath, [platformScript, ...args], {
       encoding: 'utf8', timeout: 15000,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
@@ -60,7 +62,7 @@ function gh(args) {
  */
 async function getTaskContext(client, taskId) {
   const { rows: [task] } = await client.query(
-    'SELECT id, title, status, phase, priority, github_issue, category FROM tasks WHERE id = $1',
+    'SELECT id, title, status, phase, priority, issue_ref, category FROM tasks WHERE id = $1',
     [taskId]
   );
   if (!task) return { error: `Task ${taskId} not found` };
@@ -73,13 +75,16 @@ async function getTaskContext(client, taskId) {
     [taskId]
   );
 
-  // GitHub issue body if linked
-  let githubBody = null;
-  if (task.github_issue) {
-    githubBody = gh(['issue', 'view', String(task.github_issue), '--json', 'body', '-q', '.body']);
+  // Issue body if linked — fetched via platform abstraction layer
+  let issueBody = null;
+  if (task.issue_ref) {
+    const raw = platform(['issue', 'view', String(task.issue_ref)]);
+    if (raw) {
+      try { issueBody = JSON.parse(raw).body || null; } catch (_) { issueBody = raw; }
+    }
   }
 
-  return { task, findings, githubBody };
+  return { task, findings, issueBody };
 }
 
 /**
@@ -125,7 +130,7 @@ async function getSecurityFindings(client, options = {}) {
   const whereClause = where.length > 0 ? `WHERE ${where.join(' AND ')}` : '';
   const { rows } = await client.query(
     `SELECT id, source, severity, confidence, location, category, description, impact,
-            remediation, effort, status, github_issue
+            remediation, effort, status, issue_ref
      FROM findings ${whereClause}
      ORDER BY CASE severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'MEDIUM' THEN 2 ELSE 3 END
      LIMIT 50`,
@@ -163,7 +168,7 @@ async function getSessionContext(client) {
     'SELECT num, date, summary, tests FROM sessions ORDER BY num DESC LIMIT 1'
   );
   const { rows: tasks } = await client.query(
-    "SELECT id, title, status, github_issue FROM tasks WHERE status NOT IN ('done', 'deferred') ORDER BY id"
+    "SELECT id, title, status, issue_ref FROM tasks WHERE status NOT IN ('done', 'deferred') ORDER BY id"
   );
   const { rows: [{ count: gotchaCount }] } = await client.query(
     'SELECT COUNT(*) FROM gotchas WHERE active = TRUE'
@@ -192,19 +197,27 @@ function getBuildState(planPath) {
 }
 
 /**
- * GitHub issue context: body + comments for A2A communication.
- * Uses execFileSync (no shell) to prevent injection.
+ * Issue context: body + comments for A2A communication.
+ * Uses platform.js (no shell) to prevent injection and support multiple platforms.
  */
 function getGitHubContext(issueNum) {
   const num = String(issueNum);
-  const body = gh(['issue', 'view', num, '--json', 'body,title,state,labels']);
-  if (!body) return { error: `Could not fetch issue #${num} — gh CLI not available or issue not found` };
+  const raw = platform(['issue', 'view', num]);
+  if (!raw) return { error: `Could not fetch issue #${num} — platform CLI not available or issue not found` };
 
-  const comments = gh(['issue', 'view', num, '--json', 'comments', '-q', '.comments[].body']);
+  let issue;
+  try { issue = JSON.parse(raw); } catch (_) {
+    return { error: `Could not parse issue #${num} response` };
+  }
+
+  // platform.js issue view returns title,body,state,comments,labels
+  const comments = issue.comments
+    ? issue.comments.map((c) => c.body).join('\n---\n')
+    : '(no comments)';
 
   return {
-    issue: JSON.parse(body),
-    comments: comments || '(no comments)',
+    issue,
+    comments,
   };
 }
 

--- a/scripts/pipeline-db.js
+++ b/scripts/pipeline-db.js
@@ -11,14 +11,14 @@
  *   node pipeline-db.js update session <num> <tests> "<summary>" # Record a session
  *   node pipeline-db.js update task new "<title>" [phase] [issue] # Create a task
  *   node pipeline-db.js update task <id> <status>                # Update task status
- *   node pipeline-db.js update task <id> github_issue <N>        # Link task to GitHub issue
+ *   node pipeline-db.js update task <id> issue_ref <N>           # Link task to issue/work-item
  *   node pipeline-db.js update task <id> readme_label "<text>"   # Set roadmap display label
  *   node pipeline-db.js update task <id> category <value>        # Set category (roadmap|build|finding|internal)
  *   node pipeline-db.js update gotcha new "<issue>" "<rule>"     # Add a gotcha
  *   node pipeline-db.js update decision "<topic>" "<decision>" "<reason>"  # Record a decision
  *   node pipeline-db.js update finding new '<json>'              # Insert finding record
  *   node pipeline-db.js update finding <id> status <status>      # Update finding status
- *   node pipeline-db.js update finding <id> github_issue <N>     # Link to GitHub issue
+ *   node pipeline-db.js update finding <id> issue_ref <N>        # Link to issue/work-item
  *   node pipeline-db.js update finding <id> commit <SHA>         # Record fix commit
  *   node pipeline-db.js get finding <id>                         # Get single finding as JSON
  *   node pipeline-db.js query findings [--status X] [--source Y] [--severity Z]  # Filter findings
@@ -97,7 +97,7 @@ async function cmdStatus() {
   const client = await connect(CONFIG);
   try {
     const sessions = await client.query('SELECT num, date, summary, tests FROM sessions ORDER BY num DESC LIMIT 3');
-    const tasks = await client.query("SELECT id, title, status, github_issue, phase FROM tasks WHERE status NOT IN ('done', 'deferred') ORDER BY id");
+    const tasks = await client.query("SELECT id, title, status, issue_ref, phase FROM tasks WHERE status NOT IN ('done', 'deferred') ORDER BY id");
     const gotchas = await client.query('SELECT issue, rule FROM gotchas WHERE active = TRUE ORDER BY id');
 
     console.log('\n' + c.bold(`═══ ${CONFIG.project} — Session Context ═══`));
@@ -125,7 +125,7 @@ async function cmdStatus() {
       console.log(`  ${c.green('No open tasks.')}`);
     } else {
       tasks.rows.forEach(t => {
-        const issue = t.github_issue ? c.dim(` #${t.github_issue}`) : '';
+        const issue = t.issue_ref ? c.dim(` #${t.issue_ref}`) : '';
         console.log(`  ${statusIcon(t.status)} [${t.id}] ${t.title}${issue}`);
       });
     }
@@ -178,7 +178,7 @@ async function cmdUpdate(args) {
           process.exit(1);
         }
         const r = await client.query(
-          'INSERT INTO tasks (title, status, phase, github_issue) VALUES ($1, $2, $3, $4) RETURNING id',
+          'INSERT INTO tasks (title, status, phase, issue_ref) VALUES ($1, $2, $3, $4) RETURNING id',
           [title, 'pending', phase, issue]
         );
         console.log(c.green(`Task #${r.rows[0].id} "${title}" created.`));
@@ -187,16 +187,16 @@ async function cmdUpdate(args) {
         const taskId = parseInt(idOrNew);
         if (isNaN(taskId)) { console.error('Task ID must be a number.'); process.exit(1); }
 
-        // Field-specific updates: update task <id> github_issue|readme_label|category <value>
-        if (fieldOrStatus === 'github_issue') {
+        // Field-specific updates: update task <id> issue_ref|readme_label|category <value>
+        if (fieldOrStatus === 'issue_ref') {
           const value = parseInt(valueParts[0]);
-          if (isNaN(value)) { console.error('Usage: update task <id> github_issue <N>'); process.exit(1); }
+          if (isNaN(value)) { console.error('Usage: update task <id> issue_ref <N>'); process.exit(1); }
           const r = await client.query(
-            'UPDATE tasks SET github_issue=$1, updated_at=NOW() WHERE id=$2 RETURNING title',
+            'UPDATE tasks SET issue_ref=$1, updated_at=NOW() WHERE id=$2 RETURNING title',
             [value, taskId]
           );
           if (r.rowCount === 0) { console.error(`Task #${taskId} not found.`); process.exit(1); }
-          console.log(c.green(`Task #${taskId} "${r.rows[0].title}" linked to issue #${value}`));
+          console.log(c.green(`Task #${taskId} "${r.rows[0].title}" linked to issue/work-item #${value}`));
 
         } else if (fieldOrStatus === 'readme_label') {
           const value = valueParts.join(' ');
@@ -227,7 +227,7 @@ async function cmdUpdate(args) {
           const status = fieldOrStatus;
           const valid = ['pending', 'in_progress', 'done', 'deferred'];
           if (!valid.includes(status)) {
-            console.error(`Status must be one of: ${valid.join(', ')}\nOr use a field name: github_issue | readme_label | category`);
+            console.error(`Status must be one of: ${valid.join(', ')}\nOr use a field name: issue_ref | readme_label | category`);
             process.exit(1);
           }
           const r = await client.query(
@@ -316,13 +316,13 @@ async function cmdUpdate(args) {
           if (r.rowCount === 0) { console.error(`Finding ${idOrNew} not found.`); process.exit(1); }
           console.log(c.green(`Finding ${idOrNew} → ${value}`));
 
-        } else if (field === 'github_issue') {
+        } else if (field === 'issue_ref') {
           const r = await client.query(
-            'UPDATE findings SET github_issue=$1, updated_at=NOW() WHERE id=$2 RETURNING id',
+            'UPDATE findings SET issue_ref=$1, updated_at=NOW() WHERE id=$2 RETURNING id',
             [parseInt(value), idOrNew]
           );
           if (r.rowCount === 0) { console.error(`Finding ${idOrNew} not found.`); process.exit(1); }
-          console.log(c.green(`Finding ${idOrNew} linked to issue #${value}`));
+          console.log(c.green(`Finding ${idOrNew} linked to issue/work-item #${value}`));
 
         } else if (field === 'commit') {
           const r = await client.query(
@@ -333,7 +333,7 @@ async function cmdUpdate(args) {
           console.log(c.green(`Finding ${idOrNew} commit → ${value.substring(0, 8)}`));
 
         } else {
-          console.error(`Unknown finding field "${field}". Use: status | github_issue | commit`);
+          console.error(`Unknown finding field "${field}". Use: status | issue_ref | commit`);
           process.exit(1);
         }
       }
@@ -400,7 +400,7 @@ async function cmdQueryFindings(args) {
   if (filters.severity) { params.push(filters.severity.toUpperCase()); conditions.push(`severity = $${params.length}`); }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
-  const sql = `SELECT id, source, severity, confidence, location, category, description, effort, status, github_issue, commit_sha
+  const sql = `SELECT id, source, severity, confidence, location, category, description, effort, status, issue_ref, commit_sha
                FROM findings ${where}
                ORDER BY CASE severity WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'MEDIUM' THEN 2 WHEN 'LOW' THEN 3 ELSE 4 END, created_at`;
 
@@ -555,14 +555,14 @@ ${c.dim(`Database: ${CONFIG.database} @ ${CONFIG.host}:${CONFIG.port}`)}
   ${c.cyan('update session')} <num> <tests> "<summary>"
       Insert or replace a session record
 
-  ${c.cyan('update task new')} "<title>" [phase] [github_issue_num]
+  ${c.cyan('update task new')} "<title>" [phase] [issue_ref_num]
       Add a new task
 
   ${c.cyan('update task')} <id> <status>
       Update task status (pending | in_progress | done | deferred)
 
-  ${c.cyan('update task')} <id> github_issue <N>
-      Link task to a GitHub issue
+  ${c.cyan('update task')} <id> issue_ref <N>
+      Link task to an issue/work-item
 
   ${c.cyan('update task')} <id> readme_label "<text>"
       Set the roadmap display label (shown in README)
@@ -584,8 +584,8 @@ ${c.dim(`Database: ${CONFIG.database} @ ${CONFIG.host}:${CONFIG.port}`)}
   ${c.cyan('update finding')} <id> status <status>
       Update finding status (triaged | in_progress | fixed | verified | wontfix)
 
-  ${c.cyan('update finding')} <id> github_issue <N>
-      Link finding to a GitHub issue
+  ${c.cyan('update finding')} <id> issue_ref <N>
+      Link finding to an issue/work-item
 
   ${c.cyan('update finding')} <id> commit <SHA>
       Record the fix commit for a finding

--- a/scripts/platform.js
+++ b/scripts/platform.js
@@ -1,0 +1,682 @@
+#!/usr/bin/env node
+/**
+ * platform.js — Platform abstraction layer for Pipeline
+ *
+ * Unified interface for issue tracking and code hosting operations.
+ * Agents call this like any shell command — stdout on success, stderr on failure.
+ * All verification, retry, and auth logic lives here in code, not in agent prompts.
+ *
+ * Backends: GitHub (gh CLI), Azure DevOps (az CLI + az rest)
+ *
+ * Usage:
+ *   node platform.js issue create --title "Fix bug" --body "Description" --labels "pipeline,roadmap"
+ *   node platform.js issue comment <ref> "Comment text"
+ *   node platform.js issue comment <ref> --stdin           # Read body from stdin
+ *   node platform.js issue close <ref>
+ *   node platform.js issue list --labels "pipeline" --state open
+ *   node platform.js issue view <ref>
+ *   node platform.js issue edit <ref> --body "New body"
+ *   node platform.js issue reopen <ref>
+ *   node platform.js issue search <query> --state open
+ *
+ *   node platform.js pr create --title "feat: X" --body "Description" --source feat/x --target main
+ *   node platform.js pr merge <ref> --squash
+ *   node platform.js pr comment <ref> "Review findings"
+ *   node platform.js pr comment <ref> --stdin              # Read body from stdin
+ *   node platform.js pr diff <ref>
+ *   node platform.js pr view <ref>
+ *
+ *   node platform.js auth check                            # Verify credentials
+ *
+ * Exit codes:
+ *   0 — success (ref/URL/data on stdout)
+ *   1 — failure (error message on stderr)
+ */
+
+const { execFile: execFileCb } = require('child_process');
+const { promisify } = require('util');
+const fs = require('fs');
+const path = require('path');
+
+const execFile = promisify(execFileCb);
+
+// ─── ANSI ──────────────────────────────────────────────────────────────────
+
+const c = {
+  red:    (s) => `\x1b[31m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  dim:    (s) => `\x1b[2m${s}\x1b[0m`,
+};
+
+// ─── CONFIG ────────────────────────────────────────────────────────────────
+
+function findProjectRoot() {
+  if (process.env.PROJECT_ROOT) return process.env.PROJECT_ROOT;
+  let dir = process.cwd();
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    dir = path.dirname(dir);
+  }
+  return process.cwd();
+}
+
+function loadPlatformConfig() {
+  const root = findProjectRoot();
+  const configPath = path.join(root, '.claude', 'pipeline.yml');
+  if (!fs.existsSync(configPath)) {
+    return { code_host: 'github', issue_tracker: 'github' };
+  }
+
+  const content = fs.readFileSync(configPath, 'utf8');
+  const platformMatch = content.match(/^platform:\s*$/m);
+  if (!platformMatch) {
+    return { code_host: 'github', issue_tracker: 'github' };
+  }
+
+  // Simple YAML extraction — no dependency needed for flat config
+  const lines = content.split('\n');
+  const startIdx = lines.indexOf('platform:');
+  if (startIdx === -1) return { code_host: 'github', issue_tracker: 'github' };
+
+  const config = { code_host: 'github', issue_tracker: 'github', azure_devops: {} };
+
+  let inPlatform = false;
+  let inAzure = false;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // Stop at next top-level key (no leading whitespace)
+    if (line.match(/^\S/) && line.trim() !== '') break;
+    if (line.trim() === '' || line.trim().startsWith('#')) continue;
+
+    const indent = line.match(/^(\s*)/)[1].length;
+    const kvMatch = line.trim().match(/^(\w+):\s*["']?([^"'\s#]+)["']?/);
+    if (!kvMatch) continue;
+
+    const [, key, value] = kvMatch;
+
+    if (indent <= 4 && key === 'code_host') { config.code_host = value; inAzure = false; }
+    else if (indent <= 4 && key === 'issue_tracker') { config.issue_tracker = value; inAzure = false; }
+    else if (indent <= 4 && key === 'azure_devops') { inAzure = true; continue; }
+    else if (inAzure || indent > 4) {
+      config.azure_devops[key] = value;
+      inAzure = true;
+    }
+  }
+
+  // Also extract project.repo for GitHub operations
+  const repoMatch = content.match(/^\s+repo:\s*["']?([^"'\s#]+)["']?/m);
+  if (repoMatch) config.repo = repoMatch[1];
+
+  return config;
+}
+
+// ─── RETRY ─────────────────────────────────────────────────────────────────
+
+const TRANSIENT_PATTERNS = [
+  /ETIMEDOUT/i,
+  /ECONNRESET/i,
+  /ECONNREFUSED/i,
+  /socket hang up/i,
+  /rate limit/i,
+  /429/,
+  /502/,
+  /503/,
+  /504/,
+  /network error/i,
+  /connect EHOSTUNREACH/i,
+];
+
+function isTransient(err) {
+  const msg = (err.stderr || err.message || '').toString();
+  return TRANSIENT_PATTERNS.some((p) => p.test(msg));
+}
+
+async function withRetry(fn, { maxAttempts = 3, baseDelay = 2000 } = {}) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt === maxAttempts || !isTransient(err)) throw err;
+      const delay = baseDelay * Math.pow(2, attempt - 1); // 2s, 4s, 8s
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+// ─── EXEC HELPERS ──────────────────────────────────────────────────────────
+
+async function run(cmd, args) {
+  try {
+    const { stdout } = await execFile(cmd, args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 60000,
+    });
+    return stdout.trim();
+  } catch (err) {
+    const msg = (err.stderr || err.message || '').toString().trim();
+    throw Object.assign(new Error(msg), { stderr: msg, exitCode: err.code });
+  }
+}
+
+function parseJson(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+// Escape single quotes for WIQL string literals ('' is the WIQL escape for ')
+function escapeWiql(s) {
+  return String(s).replace(/'/g, "''");
+}
+
+// ─── STDIN READER ──────────────────────────────────────────────────────────
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    if (process.stdin.isTTY) {
+      resolve('');
+      return;
+    }
+    const chunks = [];
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => chunks.push(chunk));
+    process.stdin.on('end', () => resolve(chunks.join('')));
+    process.stdin.on('error', reject);
+  });
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GITHUB BACKEND
+// ═══════════════════════════════════════════════════════════════════════════
+
+const github = {
+  async authCheck() {
+    await run('gh', ['auth', 'status']);
+    return 'GitHub authentication verified';
+  },
+
+  // ─── Issues ────────────────────────────────────────────────────────────
+
+  async issueCreate({ title, body, labels, repo }) {
+    const args = ['issue', 'create', '--repo', repo, '--title', title];
+    if (body) args.push('--body', body);
+    if (labels) args.push('--label', labels);
+    args.push('--json', 'number', '-q', '.number');
+
+    const ref = await withRetry(() => run('gh', args));
+    // Verify it was created
+    await run('gh', ['issue', 'view', ref, '--repo', repo, '--json', 'number', '-q', '.number']);
+    return ref;
+  },
+
+  async issueComment({ ref, body, repo }) {
+    await withRetry(() => run('gh', ['issue', 'comment', String(ref), '--repo', repo, '--body', body]));
+    return String(ref);
+  },
+
+  async issueClose({ ref, comment, repo }) {
+    const args = ['issue', 'close', String(ref), '--repo', repo];
+    if (comment) args.push('--comment', comment);
+    await withRetry(() => run('gh', args));
+    // Verify it actually closed
+    const state = await run('gh', ['issue', 'view', String(ref), '--repo', repo, '--json', 'state', '-q', '.state']);
+    if (state !== 'CLOSED') {
+      throw new Error(`Issue ${ref} state is "${state}" after close attempt — expected CLOSED`);
+    }
+    return String(ref);
+  },
+
+  async issueList({ labels, state, search, repo, limit }) {
+    const args = ['issue', 'list', '--repo', repo];
+    if (labels) args.push('--label', labels);
+    if (state) args.push('--state', state);
+    if (search) args.push('--search', search);
+    if (limit) args.push('--limit', String(limit));
+    args.push('--json', 'number,title,state,labels,url');
+    return await run('gh', args);
+  },
+
+  async issueView({ ref, repo }) {
+    return await run('gh', ['issue', 'view', String(ref), '--repo', repo, '--json', 'title,body,state,comments,labels']);
+  },
+
+  async issueEdit({ ref, body, repo }) {
+    await withRetry(() => run('gh', ['issue', 'edit', String(ref), '--repo', repo, '--body', body]));
+    return String(ref);
+  },
+
+  async issueReopen({ ref, repo }) {
+    await withRetry(() => run('gh', ['issue', 'reopen', String(ref), '--repo', repo]));
+    const state = await run('gh', ['issue', 'view', String(ref), '--repo', repo, '--json', 'state', '-q', '.state']);
+    if (state !== 'OPEN') {
+      throw new Error(`Issue ${ref} state is "${state}" after reopen attempt — expected OPEN`);
+    }
+    return String(ref);
+  },
+
+  async issueSearch({ query, state, repo, limit }) {
+    const args = ['issue', 'list', '--repo', repo];
+    if (query) args.push('--search', query);
+    if (state) args.push('--state', state);
+    if (limit) args.push('--limit', String(limit));
+    args.push('--json', 'number,title,state,labels');
+    return await run('gh', args);
+  },
+
+  // ─── PRs ───────────────────────────────────────────────────────────────
+
+  async prCreate({ title, body, source, target, repo }) {
+    const args = ['pr', 'create', '--repo', repo, '--title', title, '--head', source];
+    if (target) args.push('--base', target);
+    if (body) args.push('--body', body);
+    args.push('--json', 'number', '-q', '.number');
+
+    const ref = await withRetry(() => run('gh', args));
+    await run('gh', ['pr', 'view', ref, '--repo', repo, '--json', 'number', '-q', '.number']);
+    return ref;
+  },
+
+  async prMerge({ ref, squash, deleteSourceBranch, message, repo }) {
+    const args = ['pr', 'merge', String(ref), '--repo', repo];
+    if (squash) args.push('--squash');
+    if (deleteSourceBranch) args.push('--delete-branch');
+    if (message) args.push('--body', message);
+
+    await withRetry(() => run('gh', args));
+    // Verify merge
+    const state = await run('gh', ['pr', 'view', String(ref), '--repo', repo, '--json', 'state', '-q', '.state']);
+    if (state !== 'MERGED') {
+      throw new Error(`PR ${ref} state is "${state}" after merge attempt — expected MERGED. Check for merge conflicts or branch protection rules.`);
+    }
+    return String(ref);
+  },
+
+  async prComment({ ref, body, repo }) {
+    await withRetry(() => run('gh', ['pr', 'comment', String(ref), '--repo', repo, '--body', body]));
+    return String(ref);
+  },
+
+  async prDiff({ ref, repo }) {
+    return await run('gh', ['pr', 'diff', String(ref), '--repo', repo]);
+  },
+
+  async prView({ ref, repo }) {
+    return await run('gh', ['pr', 'view', String(ref), '--repo', repo, '--json', 'number,title,state,body,headRefName,baseRefName']);
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AZURE DEVOPS BACKEND
+// ═══════════════════════════════════════════════════════════════════════════
+
+const azureDevops = {
+  async authCheck(config) {
+    await run('az', ['account', 'show', '--query', 'name', '--output', 'tsv']);
+    // Verify DevOps extension is installed
+    await run('az', ['extension', 'show', '--name', 'azure-devops', '--query', 'version', '--output', 'tsv']);
+    // Verify project access
+    const org = config.azure_devops.organization;
+    const project = config.azure_devops.project;
+    await run('az', ['devops', 'project', 'show', '--project', project, '--org', `https://dev.azure.com/${org}`, '--query', 'name', '--output', 'tsv']);
+    return 'Azure DevOps authentication verified';
+  },
+
+  _orgArgs(config) {
+    const org = config.azure_devops.organization;
+    const project = config.azure_devops.project;
+    return ['--org', `https://dev.azure.com/${org}`, '--project', project];
+  },
+
+  // ─── Issues (Work Items) ──────────────────────────────────────────────
+
+  async issueCreate({ title, body, labels, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const workItemType = config.azure_devops.work_item_type || 'Task';
+    const args = ['boards', 'work-item', 'create', '--type', workItemType, '--title', title, ...orgArgs, '--output', 'json'];
+    if (body) args.push('--description', body);
+    if (labels) args.push('--fields', `System.Tags=${labels.replace(/,/g, ';')}`);
+
+    const raw = await withRetry(() => run('az', args));
+    const data = parseJson(raw);
+    if (!data || !data.id) throw new Error('Failed to parse work item ID from response');
+    // Verify it exists
+    await run('az', ['boards', 'work-item', 'show', '--id', String(data.id), ...orgArgs, '--output', 'json']);
+    return String(data.id);
+  },
+
+  async issueComment({ ref, body, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    await withRetry(() => run('az', ['boards', 'work-item', 'update', '--id', String(ref), '--discussion', body, ...orgArgs, '--output', 'json']));
+    return String(ref);
+  },
+
+  async issueClose({ ref, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const doneState = config.azure_devops.done_state || 'Closed';
+    await withRetry(() => run('az', ['boards', 'work-item', 'update', '--id', String(ref), '--state', doneState, ...orgArgs, '--output', 'json']));
+    // Verify state actually changed
+    const raw = await run('az', ['boards', 'work-item', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+    const data = parseJson(raw);
+    const currentState = data?.fields?.['System.State'];
+    if (currentState !== doneState) {
+      throw new Error(`Work item ${ref} state is "${currentState}" after close — expected "${doneState}". Check valid transitions for your process template.`);
+    }
+    return String(ref);
+  },
+
+  async issueList({ labels, state, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const doneState = config.azure_devops.done_state || 'Closed';
+    const activeState = config.azure_devops.active_state || 'Active';
+
+    let whereClause = '[System.TeamProject] = @project';
+    if (labels) {
+      const tags = labels.split(',').map((t) => `[System.Tags] CONTAINS '${escapeWiql(t.trim())}'`);
+      whereClause += ` AND ${tags.join(' AND ')}`;
+    }
+    if (state === 'open') {
+      whereClause += ` AND [System.State] <> '${doneState}'`;
+    } else if (state === 'closed') {
+      whereClause += ` AND [System.State] = '${doneState}'`;
+    }
+
+    const wiql = `SELECT [System.Id],[System.Title],[System.State],[System.Tags] FROM workitems WHERE ${whereClause} ORDER BY [System.Id]`;
+    return await run('az', ['boards', 'query', '--wiql', wiql, ...orgArgs, '--output', 'json']);
+  },
+
+  async issueView({ ref, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    return await run('az', ['boards', 'work-item', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+  },
+
+  async issueEdit({ ref, body, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    await withRetry(() => run('az', ['boards', 'work-item', 'update', '--id', String(ref), '--description', body, ...orgArgs, '--output', 'json']));
+    return String(ref);
+  },
+
+  async issueReopen({ ref, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const activeState = config.azure_devops.active_state || 'Active';
+    await withRetry(() => run('az', ['boards', 'work-item', 'update', '--id', String(ref), '--state', activeState, ...orgArgs, '--output', 'json']));
+    const raw = await run('az', ['boards', 'work-item', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+    const data = parseJson(raw);
+    const currentState = data?.fields?.['System.State'];
+    if (currentState !== activeState) {
+      throw new Error(`Work item ${ref} state is "${currentState}" after reopen — expected "${activeState}"`);
+    }
+    return String(ref);
+  },
+
+  async issueSearch({ query, state, config, limit }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const doneState = config.azure_devops.done_state || 'Closed';
+
+    let whereClause = `[System.TeamProject] = @project AND [System.Title] CONTAINS '${escapeWiql(query)}'`;
+    if (state === 'open') {
+      whereClause += ` AND [System.State] <> '${doneState}'`;
+    }
+
+    const wiql = `SELECT [System.Id],[System.Title],[System.State],[System.Tags] FROM workitems WHERE ${whereClause} ORDER BY [System.Id]`;
+    const args = ['boards', 'query', '--wiql', wiql, ...orgArgs, '--output', 'json'];
+    if (limit) args.push('--top', String(limit));
+    return await run('az', args);
+  },
+
+  // ─── PRs ───────────────────────────────────────────────────────────────
+
+  async prCreate({ title, body, source, target, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const args = ['repos', 'pr', 'create', '--title', title, '--source-branch', source, ...orgArgs, '--output', 'json'];
+    if (target) args.push('--target-branch', target);
+    if (body) args.push('--description', body);
+
+    const raw = await withRetry(() => run('az', args));
+    const data = parseJson(raw);
+    if (!data || !data.pullRequestId) throw new Error('Failed to parse PR ID from response');
+    return String(data.pullRequestId);
+  },
+
+  async prMerge({ ref, squash, deleteSourceBranch, message, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const args = ['repos', 'pr', 'update', '--id', String(ref), '--status', 'completed', ...orgArgs, '--output', 'json'];
+    if (squash) args.push('--squash', 'true');
+    if (deleteSourceBranch) args.push('--delete-source-branch', 'true');
+    if (message) args.push('--merge-commit-message', message);
+
+    await withRetry(() => run('az', args));
+    // Verify merge status
+    const raw = await run('az', ['repos', 'pr', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+    const data = parseJson(raw);
+    if (data?.status !== 'completed') {
+      throw new Error(`PR ${ref} status is "${data?.status}" after merge — expected "completed". Check merge policies or conflicts.`);
+    }
+    return String(ref);
+  },
+
+  async prComment({ ref, body, config }) {
+    const org = config.azure_devops.organization;
+    const project = config.azure_devops.project;
+
+    // Get repository ID from PR
+    const orgArgs = azureDevops._orgArgs(config);
+    const prRaw = await run('az', ['repos', 'pr', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+    const prData = parseJson(prRaw);
+    const repoId = prData?.repository?.id;
+    if (!repoId) throw new Error('Could not determine repository ID from PR');
+
+    const uri = `https://dev.azure.com/${org}/${project}/_apis/git/repositories/${repoId}/pullRequests/${ref}/threads?api-version=7.2`;
+    const payload = JSON.stringify({
+      comments: [{ parentCommentId: 0, content: body, commentType: 'text' }],
+      status: 'closed',
+    });
+
+    await withRetry(() => run('az', ['rest', '--method', 'POST', '--uri', uri, '--body', payload]));
+    return String(ref);
+  },
+
+  async prDiff({ ref, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    const raw = await run('az', ['repos', 'pr', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+    const data = parseJson(raw);
+    const source = data?.sourceRefName?.replace('refs/heads/', '');
+    const target = data?.targetRefName?.replace('refs/heads/', '');
+    if (!source || !target) throw new Error('Could not determine source/target branches from PR');
+    return await run('git', ['diff', `${target}...${source}`]);
+  },
+
+  async prView({ ref, config }) {
+    const orgArgs = azureDevops._orgArgs(config);
+    return await run('az', ['repos', 'pr', 'show', '--id', String(ref), ...orgArgs, '--output', 'json']);
+  },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FALLBACK (no platform configured)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const fallback = {
+  async authCheck() {
+    return 'SKIPPED — no platform configured';
+  },
+
+  async issueCreate() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueComment() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueClose() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueList() { process.stdout.write('[]'); return '[]'; },
+  async issueView() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueEdit() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueReopen() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async issueSearch() { process.stdout.write('[]'); return '[]'; },
+
+  async prCreate() { throw new Error('PLATFORM_TWO_STORE: No code host configured. Cannot create PR. Set platform.code_host in .claude/pipeline.yml'); },
+  async prMerge() { throw new Error('PLATFORM_TWO_STORE: No code host configured. Cannot merge PR.'); },
+  async prComment() { process.stdout.write('SKIPPED'); return 'SKIPPED'; },
+  async prDiff() { throw new Error('PLATFORM_TWO_STORE: No code host configured. Cannot get PR diff.'); },
+  async prView() { throw new Error('PLATFORM_TWO_STORE: No code host configured. Cannot view PR.'); },
+};
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DISPATCHER
+// ═══════════════════════════════════════════════════════════════════════════
+
+function getBackend(type, config) {
+  const platform = type === 'issue' ? config.issue_tracker : config.code_host;
+
+  switch (platform) {
+    case 'github':
+      return github;
+    case 'azure-devops':
+      return azureDevops;
+    case 'none':
+      return fallback;
+    default:
+      throw new Error(`PLATFORM_TWO_STORE: Unsupported platform "${platform}" for ${type} operations. Supported: github, azure-devops, none`);
+  }
+}
+
+// ─── ARG PARSING ───────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = { positional: [], flags: {} };
+
+  let i = 0;
+  while (i < args.length) {
+    if (args[i].startsWith('--')) {
+      const key = args[i].slice(2);
+      if (key === 'stdin') {
+        result.flags.stdin = true;
+        i++;
+      } else if (key === 'squash' || key === 'delete-branch') {
+        result.flags[key] = true;
+        i++;
+      } else if (i + 1 < args.length && !args[i + 1].startsWith('--')) {
+        result.flags[key] = args[i + 1];
+        i += 2;
+      } else {
+        result.flags[key] = true;
+        i++;
+      }
+    } else {
+      result.positional.push(args[i]);
+      i++;
+    }
+  }
+
+  return result;
+}
+
+// ─── MAIN ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  const { positional, flags } = parseArgs(process.argv);
+  const [resource, action, ...rest] = positional;
+
+  if (!resource || !action) {
+    process.stderr.write('Usage: node platform.js <issue|pr|auth> <action> [args] [--flags]\n');
+    process.exit(1);
+  }
+
+  const config = loadPlatformConfig();
+
+  // Read body from stdin if --stdin flag is set
+  let stdinBody = null;
+  if (flags.stdin) {
+    stdinBody = await readStdin();
+    if (!stdinBody.trim()) {
+      process.stderr.write('Error: --stdin flag set but no input received on stdin\n');
+      process.exit(1);
+    }
+  }
+
+  try {
+    let result;
+
+    if (resource === 'auth' && action === 'check') {
+      // Auth check — verify both configured platforms
+      const results = [];
+      const issueBackend = getBackend('issue', config);
+      const codeBackend = getBackend('pr', config);
+
+      results.push(await issueBackend.authCheck(config));
+      if (config.issue_tracker !== config.code_host) {
+        results.push(await codeBackend.authCheck(config));
+      }
+      result = results.join('\n');
+
+    } else if (resource === 'issue') {
+      const backend = getBackend('issue', config);
+      const repo = flags.repo || config.repo;
+
+      switch (action) {
+        case 'create':
+          result = await backend.issueCreate({ title: flags.title, body: stdinBody || flags.body, labels: flags.labels || flags.label, repo, config });
+          break;
+        case 'comment':
+          result = await backend.issueComment({ ref: rest[0], body: stdinBody || rest[1] || flags.body, repo, config });
+          break;
+        case 'close':
+          result = await backend.issueClose({ ref: rest[0], comment: flags.comment, repo, config });
+          break;
+        case 'list':
+          result = await backend.issueList({ labels: flags.labels || flags.label, state: flags.state, search: flags.search, repo, limit: flags.limit, config });
+          break;
+        case 'view':
+          result = await backend.issueView({ ref: rest[0], repo, config });
+          break;
+        case 'edit':
+          result = await backend.issueEdit({ ref: rest[0], body: stdinBody || flags.body, repo, config });
+          break;
+        case 'reopen':
+          result = await backend.issueReopen({ ref: rest[0], repo, config });
+          break;
+        case 'search':
+          result = await backend.issueSearch({ query: rest[0] || flags.query, state: flags.state, repo, limit: flags.limit, config });
+          break;
+        default:
+          throw new Error(`Unknown issue action: ${action}. Supported: create, comment, close, list, view, edit, reopen, search`);
+      }
+
+    } else if (resource === 'pr') {
+      const backend = getBackend('pr', config);
+      const repo = flags.repo || config.repo;
+
+      switch (action) {
+        case 'create':
+          result = await backend.prCreate({ title: flags.title, body: stdinBody || flags.body, source: flags.source || flags.head, target: flags.target || flags.base, repo, config });
+          break;
+        case 'merge':
+          result = await backend.prMerge({ ref: rest[0], squash: flags.squash, deleteSourceBranch: flags['delete-branch'], message: flags.body || flags.message, repo, config });
+          break;
+        case 'comment':
+          result = await backend.prComment({ ref: rest[0], body: stdinBody || rest[1] || flags.body, repo, config });
+          break;
+        case 'diff':
+          result = await backend.prDiff({ ref: rest[0], repo, config });
+          break;
+        case 'view':
+          result = await backend.prView({ ref: rest[0], repo, config });
+          break;
+        default:
+          throw new Error(`Unknown pr action: ${action}. Supported: create, merge, comment, diff, view`);
+      }
+
+    } else {
+      throw new Error(`Unknown resource: ${resource}. Supported: issue, pr, auth`);
+    }
+
+    // Output result to stdout — agent reads this
+    if (result && result !== 'SKIPPED') {
+      process.stdout.write(String(result) + '\n');
+    }
+
+  } catch (err) {
+    process.stderr.write(`Error: ${err.message}\n`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/scripts/setup-knowledge-db.sql
+++ b/scripts/setup-knowledge-db.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS tasks (
   status TEXT DEFAULT 'pending',     -- pending, in_progress, done, deferred
   phase TEXT DEFAULT 'backlog',
   priority TEXT DEFAULT 'medium',    -- low, medium, high, critical
-  github_issue INTEGER,
+  issue_ref INTEGER,
   readme_label TEXT,                 -- bold text shown in README roadmap (null = not a roadmap item)
   category TEXT DEFAULT 'internal',  -- roadmap, build, finding, internal
   created_at TIMESTAMPTZ DEFAULT NOW(),
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS findings (
   effort TEXT NOT NULL,                   -- quick, medium, architectural, none
   verification_domain TEXT,               -- INJ, sector-api, changed-files, screenshot, manual
   status TEXT DEFAULT 'triaged',          -- triaged, in_progress, fixed, verified, wontfix
-  github_issue INTEGER,                   -- Linked GitHub issue number
+  issue_ref INTEGER,                      -- Linked issue/work-item reference
   commit_sha TEXT,                        -- Fix commit SHA
   task_id INTEGER REFERENCES tasks(id),   -- Linked pipeline task
   report_path TEXT,                       -- Original report file path
@@ -264,7 +264,7 @@ CREATE TABLE IF NOT EXISTS file_cache (
 -- ═══════════════════════════════════════════════════════════════════════════════
 
 CREATE OR REPLACE VIEW open_tasks AS
-  SELECT id, title, phase, status, priority, github_issue, created_at
+  SELECT id, title, phase, status, priority, issue_ref, created_at
   FROM tasks
   WHERE status NOT IN ('done', 'deferred')
   ORDER BY
@@ -284,7 +284,7 @@ CREATE OR REPLACE VIEW active_gotchas AS
   ORDER BY created_at DESC;
 
 CREATE OR REPLACE VIEW roadmap_tasks AS
-  SELECT id, title, readme_label, status, github_issue, category, updated_at
+  SELECT id, title, readme_label, status, issue_ref, category, updated_at
   FROM tasks
   WHERE category = 'roadmap'
   ORDER BY
@@ -293,7 +293,7 @@ CREATE OR REPLACE VIEW roadmap_tasks AS
 
 CREATE OR REPLACE VIEW open_findings AS
   SELECT id, source, severity, confidence, location, category,
-         description, effort, status, github_issue, commit_sha
+         description, effort, status, issue_ref, commit_sha
   FROM findings
   WHERE status NOT IN ('verified', 'wontfix')
   ORDER BY

--- a/skills/building/SKILL.md
+++ b/skills/building/SKILL.md
@@ -24,7 +24,7 @@ Agents read their own context from stores — the orchestrator passes references
 | Architecture plan | `docs/architecture.md` (file read) | Skip if missing |
 | Decisions | `pipeline-context.js decisions` (Postgres) | Skip if Postgres unavailable |
 | Gotchas | `pipeline-context.js gotchas` (Postgres) | Skip if Postgres unavailable |
-| Task issue | `gh issue view N` (GitHub) | Skip if GitHub disabled |
+| Task issue | `node '[SCRIPTS_DIR]/platform.js' issue view N` | Skip if platform.issue_tracker is `none` |
 | Prior tasks | `.claude/build-state.json` (file read) | First task in build |
 | Task description | Pasted in prompt (from plan) | Always available |
 
@@ -141,14 +141,15 @@ BODY
 
 Post implementation report on the task issue:
 ```
-gh issue comment [TASK_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [TASK_ISSUE] --stdin
 ## Implementation — Task [TASK_NUMBER]
 **Status:** [DONE/DONE_WITH_CONCERNS/BLOCKED/NEEDS_CONTEXT]
 **Commit:** [SHA]
 **Files changed:** [list]
 EOF
-)"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 ### 3. Build State
 

--- a/skills/building/implementer-prompt.md
+++ b/skills/building/implementer-prompt.md
@@ -71,8 +71,10 @@ Task tool (general-purpose, model: {{MODEL}}):
     Read the task issue for additional context, comments, and requirements
     from prior pipeline phases:
     ```bash
-    gh issue view [TASK_ISSUE] --repo '[GITHUB_REPO]' --json title,body,labels,comments
+    node '[SCRIPTS_DIR]/platform.js' issue view [TASK_ISSUE]
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     The issue may contain discussion, clarifications, or updated requirements.
     Read it before starting implementation.
@@ -187,7 +189,7 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     Post implementation report on the task issue:
     ```bash
-    gh issue comment [TASK_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [TASK_ISSUE] --stdin
     ## Implementation — Task [TASK_NUMBER]
     **Status:** [DONE/DONE_WITH_CONCERNS/BLOCKED/NEEDS_CONTEXT]
     **Commit:** [SHA]
@@ -196,8 +198,9 @@ Task tool (general-purpose, model: {{MODEL}}):
     [For DONE_WITH_CONCERNS: list concerns]
     [For BLOCKED/NEEDS_CONTEXT: describe what's needed]
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     ### 3. Build State
 

--- a/skills/building/reviewer-prompt.md
+++ b/skills/building/reviewer-prompt.md
@@ -50,8 +50,10 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     Read the implementer's completion report from the task issue:
     ```bash
-    gh issue view [TASK_ISSUE] --repo '[GITHUB_REPO]' --json title,body,labels,comments
+    node '[SCRIPTS_DIR]/platform.js' issue view [TASK_ISSUE]
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     Look for the most recent "## Implementation" comment — it contains the
     status, commit SHA, files changed, and any concerns. Extract the commit
@@ -254,7 +256,7 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     Post review verdict on the task issue:
     ```bash
-    gh issue comment [TASK_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [TASK_ISSUE] --stdin
     ## Post-Task Review — Task [TASK_NUMBER]
     **Verdict:** [PASS/FAIL]
     **Findings:** [N] high, [M] medium, [P] low
@@ -262,8 +264,9 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     [For FAIL: list 🔴 HIGH finding IDs + one-line descriptions]
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     ### 3. Build State
 

--- a/skills/dashboard/SKILL.md
+++ b/skills/dashboard/SKILL.md
@@ -121,8 +121,10 @@ If not found in spec, check the most recent plan file from `docs.plans_dir`.
 If a `github_epic` number is found:
 
 ```bash
-gh issue view [N] --repo '[project.repo]' --json title,body,state,comments,labels
+node '[SCRIPTS_DIR]/platform.js' issue view [N]
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 **Parse the issue body** for the status checklist (brainstorm creates this):
 - `- [x] Brainstorm` → done
@@ -138,8 +140,10 @@ If no `github_epic` found or `issue_tracking` is false: set EPIC_DATA to null.
 ### Step 5b — Fetch open issues
 
 ```bash
-gh issue list --repo '[project.repo]' --state open --limit 20 --json number,title,labels,url
+node '[SCRIPTS_DIR]/platform.js' issue search '' --state open --limit 20
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 If `issue_tracking` is true, group issues by label:
 - `pipeline:qa` → QA Failures

--- a/skills/github-tracking/SKILL.md
+++ b/skills/github-tracking/SKILL.md
@@ -112,8 +112,10 @@ Commands find the epic number through this chain:
 
 ```bash
 # Verify epic exists before commenting
-gh issue view [N] --repo '[project.repo]' --json state -q '.state' 2>/dev/null
+node '[SCRIPTS_DIR]/platform.js' issue view [N] 2>/dev/null
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 If the epic is closed or deleted, log a warning and skip. Do not create a new epic — that is brainstorm's job.
 
@@ -151,8 +153,10 @@ Do not post status updates, progress announcements, or activity signals. These a
 Before creating any child issue, check for an existing issue with the same finding ID:
 
 ```bash
-gh issue list --repo '[project.repo]' --search '[FINDING_ID] in:title' --state open --json number --limit 1
+node '[SCRIPTS_DIR]/platform.js' issue search '[FINDING_ID] in:title' --state open --limit 1
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 If an issue already exists, skip creation. This prevents duplicate issues when commands are re-run.
 

--- a/skills/qa/planner-prompt.md
+++ b/skills/qa/planner-prompt.md
@@ -213,7 +213,7 @@ Task tool (general-purpose, model: {{MODEL}}):
     Post the test plan summary as a comment on the task issue. This is the
     handoff — QA workers read this to understand their work packages.
     ```
-    gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [GITHUB_ISSUE] --stdin
     ## QA Test Plan
     **Scenarios:** [N] ([P0 count] P0, [P1 count] P1)
     **Work packages:** [M] + WP-SEAM
@@ -223,8 +223,9 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     Artifact: `docs/test-plans/[feature-name]-test-plan.md`
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     ### 3. Build State
 

--- a/skills/qa/worker-prompt.md
+++ b/skills/qa/worker-prompt.md
@@ -212,7 +212,7 @@ Task tool (general-purpose, model: {{MODEL}}):
     Post your results as a comment on the task issue. This is the handoff —
     the QA verifier reads this comment to synthesize worker results.
     ```
-    gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [GITHUB_ISSUE] --stdin
     ## QA Worker [WORK_PACKAGE_ID]: [WORK_PACKAGE_NAME]
     **Result:** [PASS/FAIL/BLOCKED] — [N] scenarios, [M] pass, [F] fail, [K] flaky
     **Confidence:** [HIGH/MEDIUM/LOW]
@@ -220,8 +220,9 @@ Task tool (general-purpose, model: {{MODEL}}):
     [For FAIL: list failing scenario IDs + one-line reason each]
     [For BLOCKED: state what blocked execution]
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     Do NOT post to the epic — `/pipeline:finish` compiles a single epic
     summary from all phase results. Task-level comments go on the task issue.

--- a/skills/redteam/recon-agent-prompt.md
+++ b/skills/redteam/recon-agent-prompt.md
@@ -294,7 +294,7 @@ Task tool (general-purpose, model: {{MODEL}}):
     Post your results as a comment on the task issue. This is the handoff —
     the red team lead reads this to assign specialist domains.
     ```
-    gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [GITHUB_ISSUE] --stdin
     ## Recon — Attack Surface Map
     - Entry points: [N]
     - Auth boundaries: [N]
@@ -303,8 +303,9 @@ Task tool (general-purpose, model: {{MODEL}}):
     - Scan scope: [diff-scoped N files | full scan]
     - SBOM: [N components | disabled]
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     Do NOT post to the epic — `/pipeline:finish` compiles a single epic
     summary from all phase results. Task-level comments go on the task issue.

--- a/skills/redteam/specialist-agent-prompt.md
+++ b/skills/redteam/specialist-agent-prompt.md
@@ -240,7 +240,7 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     Post your domain results as a comment on the task issue:
     ```
-    gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+    cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [GITHUB_ISSUE] --stdin
     ## Red Team Specialist: [DOMAIN_NAME] ([DOMAIN_ID])
     **Findings:** [N] ([C] critical, [H] high, [M] medium, [L] low)
     **Scan scope:** [diff-scoped N files | full scan]
@@ -248,8 +248,9 @@ Task tool (general-purpose, model: {{MODEL}}):
     [For findings: list finding IDs + one-line descriptions]
     [For clean cert: "Clean Domain Certificate issued"]
     EOF
-    )"
     ```
+
+    If the command fails, notify the user with the error and ask for guidance.
 
     ### 3. Build State
 

--- a/skills/remediation/SKILL.md
+++ b/skills/remediation/SKILL.md
@@ -36,7 +36,7 @@ Agents are stateless — they receive a ticket reference, read their own context
 
 | Priority | Backend | When Available | Ticket Reference | How Agents Read |
 |----------|---------|---------------|-----------------|----------------|
-| 1 | **GitHub Issues** | `integrations.github.enabled` | Issue number (`#42`) | `gh issue view 42 --json title,body,labels,comments` |
+| 1 | **Issue Tracker** | `platform.issue_tracker` is not `none` | Issue/work-item ref (`42`) | `node '[SCRIPTS_DIR]/platform.js' issue view 42` |
 | 2 | **Postgres** | `knowledge.tier == "postgres"` AND `integrations.postgres.enabled` (runs alongside GitHub when both are available) | Finding ID (`RT-INJ-001`) | `node scripts/pipeline-db.js get finding RT-INJ-001` |
 | 3 | **Files** | Always (fallback) | Finding ID in tracking file | Inline context in prompt (only fallback) |
 
@@ -227,7 +227,7 @@ BODY
 
 Post fix status as a comment on the finding's GitHub issue:
 ```
-gh issue comment [FINDING_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [FINDING_ISSUE] --stdin
 ## Fix Applied
 **Finding:** [FINDING_ID]
 **Commit:** [SHA]
@@ -236,8 +236,9 @@ gh issue comment [FINDING_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
 
 Awaiting verification by [verification strategy].
 EOF
-)"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 ### 3. Build State
 

--- a/skills/remediation/fix-planner-prompt.md
+++ b/skills/remediation/fix-planner-prompt.md
@@ -6,9 +6,10 @@ Use this template when dispatching the opus planner for architectural fixes.
 1. `{{MODEL}}` → value of `models.architecture` from pipeline.yml (e.g., `opus`)
 2. `[FINDING_ID]` → the finding ID (e.g., RT-AUTH-002)
 3. `{{TICKET_CONTEXT}}` → (same pattern as implementer/reviewer) Replace with ticket-reading instructions:
-   - **GitHub:** `Read the GitHub issue for full finding details: gh issue view [N] --repo '[repo]' --json title,body,labels,comments`
+   - **GitHub:** `Read the GitHub issue for full finding details: node '[SCRIPTS_DIR]/platform.js' issue view [N]`
    - **Postgres:** `Read the finding record: node scripts/pipeline-db.js get finding [ID]`
    - **Files (fallback):** Inline the finding record from triage output
+   - If the command fails, notify the user with the error and ask for guidance.
 4. `[AFFECTED_FILES]` → contents of all files involved in the finding
 5. `[PROJECT_CONTEXT]` → project name, framework, source_dirs, profile
 6. `[NON_NEGOTIABLE]` → review.non_negotiable[] from config

--- a/skills/reviewing/SKILL.md
+++ b/skills/reviewing/SKILL.md
@@ -150,7 +150,7 @@ BODY
 
 Post the review verdict as a comment on the task issue:
 ```
-gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
+cat <<'EOF' | node '[SCRIPTS_DIR]/platform.js' issue comment [GITHUB_ISSUE] --stdin
 ## Review
 **Verdict:** [PASS/FAIL]
 **Findings:** [N] high, [M] medium, [P] low
@@ -159,8 +159,9 @@ gh issue comment [GITHUB_ISSUE] --repo '[GITHUB_REPO]' --body "$(cat <<'EOF'
 
 [For FAIL: list 🔴 HIGH finding IDs + one-line descriptions]
 EOF
-)"
 ```
+
+If the command fails, notify the user with the error and ask for guidance.
 
 ### 3. Build State
 

--- a/templates/pipeline.yml
+++ b/templates/pipeline.yml
@@ -4,7 +4,7 @@ project:
   name: "my-project"
   repo: "owner/repo"
   branch: "main"
-  profile: null  # Set by init: spa, fullstack, mobile, mobile-web, api, cli, library
+  profile: null  # Set by init: spa, fullstack, mobile, mobile-web, api, cli, library, service, data-pipeline, automation
   pkg_manager: "npm"  # Detected from lockfile: pnpm, npm, yarn, bun
 
 # Tool commands (null to disable any gate)
@@ -251,6 +251,21 @@ integrations:
   playwright:
     enabled: false
     use_in: [ui-review]
+
+# Platform — issue tracking and code hosting
+# Detected during init from git remote URL. Agents call scripts/platform.js
+# which dispatches to the correct CLI (gh, az devops) transparently.
+platform:
+  code_host: "github"          # github, azure-devops, none
+  issue_tracker: "github"      # github, azure-devops, none
+  # Azure DevOps config (populated during init when azure-devops detected)
+  # azure_devops:
+  #   organization: ""          # Extracted from git remote URL
+  #   project: ""               # Extracted from git remote URL
+  #   process_template: ""      # Detected via az devops project show (Basic, Agile, Scrum, CMMI)
+  #   work_item_type: "Task"    # Default work item type for Pipeline-created items
+  #   done_state: ""            # Resolved from process_template (e.g., Closed, Done)
+  #   active_state: ""          # Resolved from process_template (e.g., Active, Doing)
 
 # Docs
 docs:


### PR DESCRIPTION
## Summary

- NEW `scripts/platform.js` — IssueTracker + CodeHost interfaces with GitHub and Azure DevOps backends
- Migrated 66 hardcoded `gh` CLI calls across 37 files to platform.js
- Renamed `github_issue` column to `issue_ref` in Postgres schema
- Added platform config section to `templates/pipeline.yml`
- Added platform detection + Azure DevOps setup flow to `commands/init.md`
- Added credential management docs, platform errors, and platform docs across 6 doc files

## Key design decisions

All verification + retry logic in Node.js code (zero token cost to agents). Agents treat platform.js like any shell command — exit 0/1, stdout/stderr. `execFile` for shell safety. WIQL injection prevention via `escapeWiql()`.

## Test plan

- [ ] `claude plugin validate .` passes
- [ ] No remaining `gh issue` or `gh pr` calls in commands/skills (grep verified)
- [ ] No remaining `github_issue` references (grep verified)
- [ ] Platform config section present in pipeline.yml template

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)