### PR TITLE
fix(platform): remove unsupported --json flag from gh create commands

### DIFF
--- a/scripts/platform.js
+++ b/scripts/platform.js
@@ -212,9 +212,12 @@ const github = {
     const args = ['issue', 'create', '--repo', repo, '--title', title];
     if (body) args.push('--body', body);
     if (labels) args.push('--label', labels);
-    args.push('--json', 'number', '-q', '.number');
 
-    const ref = await withRetry(() => run('gh', args));
+    // gh issue create prints the issue URL on stdout; --json is not supported here.
+    const url = await withRetry(() => run('gh', args));
+    const m = url.match(/\/issues\/(\d+)/);
+    if (!m) throw new Error(`Could not parse issue number from gh output: ${url}`);
+    const ref = m[1];
     // Verify it was created
     await run('gh', ['issue', 'view', ref, '--repo', repo, '--json', 'number', '-q', '.number']);
     return ref;
@@ -280,9 +283,12 @@ const github = {
     const args = ['pr', 'create', '--repo', repo, '--title', title, '--head', source];
     if (target) args.push('--base', target);
     if (body) args.push('--body', body);
-    args.push('--json', 'number', '-q', '.number');
 
-    const ref = await withRetry(() => run('gh', args));
+    // gh pr create prints the PR URL on stdout; --json is not supported here.
+    const url = await withRetry(() => run('gh', args));
+    const m = url.match(/\/pull\/(\d+)/);
+    if (!m) throw new Error(`Could not parse PR number from gh output: ${url}`);
+    const ref = m[1];
     await run('gh', ['pr', 'view', ref, '--repo', repo, '--json', 'number', '-q', '.number']);
     return ref;
   },


### PR DESCRIPTION
## Summary

- `platform.js` `issueCreate` and `prCreate` pushed `--json number -q .number` to `gh`, which is not supported on `gh issue create` or `gh pr create` (verified against gh 2.86.0 — `--json` is only valid on `view`/`list`/`search`).
- Fix: remove the flag; parse the issue/PR number from the URL gh prints on stdout (`/issues/N` or `/pull/N`); throw explicitly if the parse fails so no silent misbehavior.

## Test plan

- [x] Live smoke test: worktree platform.js created issue #80, returned `80`, verified via `gh issue view`, then closed. Round-trip works.
- [x] Retroactive tracking issue #81 filed through the patched abstraction — first end-to-end use of the fix.
- [x] This PR itself tests `prCreate` — if you're reading this, the fix works.

## Dogfooding note

Discovered while running `/pipeline:remediate` on `docs/findings/audit-2026-04-04.md`. The rule-enforcement tool that requires every fix to have a tracking issue was itself broken, so the issue for this fix (#81) was created _after_ the fix via the fixed tool — bootstrap exception, documented in the linked tracking issue.

## Follow-ups (to be filed as separate issues after this merges)

- Dead variable `inPlatform` in `loadPlatformConfig`
- Config parser misattributes non-Azure subsections under `platform:` — trap for future T2-T4 tracker additions
- JS static analysis (eslint + `tsc --checkJs`) for `scripts/` — tooling gap that let both `--json` bugs ship

Closes #81
