### PR TITLE
feat(orientation): Node preflight probe replaces chained Bash Step 1

### DIFF
--- a/scripts/preflight-probe.js
+++ b/scripts/preflight-probe.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Orientation preflight probe — emits the 6-point mechanical context as JSON on
+// stdout. Invoked by skills/orientation/SKILL.md Step 1. Interpretation
+// (Steps 2-3 of the orientation skill — prose output template, intent
+// comparison, base-branch and worktree guards) remains in prose and is
+// performed by the LLM on this JSON output.
+//
+// Exit codes: 0 on success; 1 on any probe failure, with a one-line stderr
+// message naming the step that failed.
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+const cwd = process.cwd();
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function step(name, fn) {
+  try {
+    return fn();
+  } catch (e) {
+    process.stderr.write(`preflight-probe: step "${name}" failed: ${e.message.split('\n')[0]}\n`);
+    process.exit(1);
+  }
+}
+
+const repo_root = step('repo_root', () => git(['rev-parse', '--show-toplevel']));
+const branch = step('branch', () => git(['branch', '--show-current']));
+const head = step('head', () => git(['rev-parse', '--short', 'HEAD']));
+
+// Worktree detector: the only authoritative git signal for a linked worktree is
+// that --git-dir and --git-common-dir resolve to different paths. Substring
+// matching a path for "worktrees" gives false positives when the repo itself
+// lives under a directory named worktrees/.
+const gitDir = step('git_dir', () => git(['rev-parse', '--git-dir']));
+const gitCommonDir = step('git_common_dir', () => git(['rev-parse', '--git-common-dir']));
+const worktree = path.resolve(cwd, gitDir) === path.resolve(cwd, gitCommonDir) ? 'MAIN' : 'WORKTREE';
+
+const statusOut = step('dirty_count', () =>
+  execFileSync('git', ['status', '--porcelain'], { cwd, encoding: 'utf8' })
+);
+const dirty_count = statusOut.trim() === '' ? 0 : statusOut.trim().split('\n').length;
+
+const output = { cwd, repo_root, branch, head, worktree, dirty_count };
+process.stdout.write(JSON.stringify(output, null, 2) + '\n');

--- a/skills/orientation/SKILL.md
+++ b/skills/orientation/SKILL.md
@@ -15,16 +15,30 @@ Every phase command's first instruction is to execute this preflight. No excepti
 
 <!-- checkpoint:MUST orientation -->
 
-## Step 1 — Assert context in a single Bash call
+## Step 1 — Run the preflight probe
 
 ```bash
-pwd && \
-  git rev-parse --show-toplevel && \
-  git branch --show-current && \
-  git rev-parse --short HEAD && \
-  { [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ] && echo 'WORKTREE' || echo 'MAIN'; } && \
-  git status --porcelain | wc -l
+node scripts/preflight-probe.js
 ```
+
+The probe emits a single JSON object on stdout with the six mechanical context
+values. Example output:
+
+```json
+{
+  "cwd": "/c/Users/user/dev/pipeline",
+  "repo_root": "/c/Users/user/dev/pipeline",
+  "branch": "main",
+  "head": "abc1234",
+  "worktree": "MAIN",
+  "dirty_count": 0
+}
+```
+
+The probe spawns git subprocesses via an argv-array API (no shell interpretation)
+and passes `cwd` explicitly to each invocation. On any probe failure it exits
+non-zero with a one-line stderr message naming which step failed — if that
+happens, stop and surface the error instead of guessing context.
 
 The worktree detector uses the only authoritative git signal: `--git-dir` and
 `--git-common-dir` return the same path in the main working tree and different


### PR DESCRIPTION
## Summary

Implements `pipeline_architect` directive #45 v1.5 (supersedes #43 v1.4). Replaces the chained-Bash mechanical probe in `skills/orientation/SKILL.md` Step 1 with a Node script that emits the six context values as JSON. Preserves the LLM interpretation layer (Steps 2-3, rationalization-prevention table, caller contract).

Closes #92.

## Changes

- `scripts/preflight-probe.js` (new, 44 lines) — emits JSON with `cwd`, `repo_root`, `branch`, `head`, `worktree`, `dirty_count`. Spawns git subprocesses via `execFileSync` with argv array (no shell interpretation); cwd passed explicitly to each invocation. Worktree detector uses `git rev-parse --git-dir` vs `--git-common-dir` (the only authoritative signal; substring matching paths for `worktrees` gives false positives). Non-zero exit with one-line stderr on any step failure.
- `skills/orientation/SKILL.md` Step 1 rewritten to invoke the probe and document the JSON shape.
- Steps 2-3, rationalization-prevention table, and caller contract unchanged — these are LLM-cognitive content the directive explicitly preserves.

## Scope rationale

All 8 phase commands (audit, build, commit, qa, redteam, review, remediate, finish) delegate to SKILL.md via the caller-contract abstraction, so replacing SKILL.md Step 1 updates all 8 callers in a single edit. Byte-for-byte sync verified programmatically across all 8 command files before and after.

## Test plan

- [x] `grep -rn "checkpoint:MUST orientation" commands skills` returns 9 files (8 phase commands + SKILL.md)
- [x] `grep -rn "pwd && git rev-parse --show-toplevel" skills commands` returns 0 matches
- [x] `node scripts/preflight-probe.js` from pipeline repo root emits valid JSON with all six fields populated, exits 0
- [x] Byte-for-byte sync: caller-contract block from `SKILL.md:84-95` appears verbatim in all 8 `commands/*.md` files

## pipeline_architect record

- Directive #45 `READY_FOR_JUDGE` (supersedes #43 v1.4, which is REJECTED)
- `exchange_log` id=24 (Engineer authoring), id=25 (advance-to-IN_PROGRESS disposition), id=26 (#43 REJECTED disposition), id=27 (Engineer completion report)
- `audit_log` captured 3 authorized UPDATEs this flow

Awaiting Judge scope-discharge review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)