### PR TITLE
feat(routing): R4 bypass-on-dispatch via input.agent_id

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,7 +19,8 @@
       "Bash(cat)",
       "Read(//c/Users/djwmo/AppData/Local/Temp/routing-test-debug/**)",
       "Bash(rm /c/Users/djwmo/.claude/projects/C--Users-djwmo-dev-pipeline/memory/project_pending_merge.md /c/Users/djwmo/.claude/projects/C--Users-djwmo-dev-pipeline/memory/project_mr_v2_session.md)",
-      "Read(//c/Users/djwmo/.claude/projects/C--Users-djwmo-dev-pipeline/memory/**)"
+      "Read(//c/Users/djwmo/.claude/projects/C--Users-djwmo-dev-pipeline/memory/**)",
+      "Bash(node scripts/hooks/routing-check.js *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ logs/*.jsonl
 worktrees/
 .claude/.active-skill
 .claude/settings.json
+.scratch/

--- a/scripts/hooks/routing-check.js
+++ b/scripts/hooks/routing-check.js
@@ -43,6 +43,16 @@ async function main() {
   const toolName  = input.tool_name  || '';
   const toolInput = input.tool_input || {};
 
+  // R4 — bypass-on-dispatch. Subagent tool calls always include `agent_id` and
+  // `agent_type` in the stdin payload (verified empirically 2026-04-26 — see
+  // memory project_r4_bypass_signal_2026-04-26). Main-thread (orchestrator)
+  // calls do not. Token-spender rules (tier-mismatch, direct-write threshold,
+  // chain-dispatch) target the orchestrator's choice of action; subagents were
+  // dispatched specifically to do the work and must not be re-constrained by
+  // the same rules. Universal floor (destructive SQL) is about the action and
+  // still applies to all callers — checked below before this guard takes effect.
+  const isSubagentCall = !!input.agent_id;
+
   const activeSkill = require('../lib/active-skill').read();
 
   let config;
@@ -81,6 +91,11 @@ async function main() {
           );
         }
       }
+    }
+
+    // Subagent bypass — rules below target Opus orchestrator choices, not subagent execution.
+    if (isSubagentCall) {
+      process.exit(0);
     }
 
     // ── Universal floor: Edit/Write above line threshold ──────────────────────


### PR DESCRIPTION
## Summary

Closes #104. Routing rules target the orchestrator's choice of action; subagents were dispatched specifically to do the work and must not be re-constrained. Per `feedback_rules_target_opus_not_subagents.md`. The bypass eliminates the previous dance of toggling routing on/off during free-form orchestration.

## How it works

`scripts/hooks/routing-check.js` reads `input.agent_id` from the PreToolUse stdin payload. If present, the hook short-circuits the agent-role rules (tier-mismatch, direct-write threshold, chain-dispatch). Universal-floor SQL block runs BEFORE the bypass guard so destructive Bash patterns still block on all callers.

## Empirical evidence (captured 2026-04-26 via `.scratch/r4/diagnostic-hook.js`)

| Call origin | `agent_id` field | `agent_type` field |
|---|---|---|
| Main-thread Bash, Read, Edit, Write, Agent (the dispatch itself) | absent | absent |
| Subagent Bash, Read, Edit, Write | present (e.g. `a5e16833ff917a96b`) | `general-purpose` |

`session_id`, `transcript_path`, `cwd`, `permission_mode` were identical. No env var (`CLAUDE_CODE_SUBAGENT`, etc.) differs. PID/PPID lineage doesn't help (each tool call spawns a fresh hook process from the Claude Code parent, not from a subagent's child process).

`agent_id` is the determinate, deterministic signal Claude Code exposes — exactly what task #104 wanted. Heuristic options (timestamp/counter) were ruled out per user 2026-04-26.

## Test plan

- [x] main-thread sonnet→building dispatch (no agent_id) — BLOCK exit 2 with tier-mismatch message
- [x] subagent sonnet→building dispatch (with agent_id) — ALLOW exit 0
- [x] main-thread Bash psql — BLOCK universal floor (`^psql\s` pattern)
- [x] subagent Bash psql — BLOCK universal floor (still applies to all callers)
- [x] guard placed AFTER universal floor, BEFORE agent-role rules
- [x] Lint clean across the changed file

## Also in this PR

- `.gitignore`: add `.scratch/` for transient diagnostic dumps
- `.claude/settings.local.json`: replace 4 exact-match Bash entries from this session's hook tests with one prefix-match per `feedback_permission_bloat.md` (CRITICAL rule against exact-match permission accumulation)

## Out of scope

- `routing-log.js` / `routing-stop.js` bypass — those are telemetry/end-of-turn, not enforcement
- Payload-schema CI smoke test — useful if Anthropic ever renames `agent_id`; tracked separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
