### PR TITLE
feat(routing): migrate hooks to plugin hooks.json + SessionStart marker init (#92, #105)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,6 +7,40 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/sync-cache.mjs\""
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/init-marker.js\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/routing-check.js\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/routing-log.js\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/routing-stop.js\""
           }
         ]
       }

--- a/scripts/hooks/init-marker.js
+++ b/scripts/hooks/init-marker.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+'use strict';
+/**
+ * init-marker.js — SessionStart hook
+ *
+ * Writes the active-skill marker to .claude/.active-skill at session start so
+ * the very first PreToolUse call has a valid marker to read. Without this,
+ * the marker file may not exist (gitignored, never committed) and routing-check.js
+ * would fall through to its FALLBACK ('conversation_mode') anyway — but doing it
+ * explicitly makes the contract observable and avoids any window where stale
+ * state from a prior session could be read.
+ *
+ * Defaults to 'conversation_mode' (matches active-skill.js FALLBACK).
+ * Always exits 0 — must never block session startup.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+try {
+  let projectRoot = process.env.PROJECT_ROOT;
+  if (!projectRoot) {
+    let dir = process.cwd();
+    while (dir !== path.dirname(dir)) {
+      if (fs.existsSync(path.join(dir, '.git'))) { projectRoot = dir; break; }
+      dir = path.dirname(dir);
+    }
+    if (!projectRoot) projectRoot = process.cwd();
+  }
+
+  const dir = path.join(projectRoot, '.claude');
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+  const target = path.join(dir, '.active-skill');
+  const tmp    = `${target}.tmp.${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify({ skill: 'conversation_mode', ts: new Date().toISOString() }), 'utf8');
+  fs.renameSync(tmp, target);
+} catch (_) {
+  // Best-effort — never block session startup
+}
+
+process.exit(0);

--- a/scripts/lib/active-skill.js
+++ b/scripts/lib/active-skill.js
@@ -14,8 +14,7 @@
 const fs   = require('fs');
 const path = require('path');
 
-const STALENESS_MS  = 60000;
-const FALLBACK      = 'conversation_mode';
+const FALLBACK = 'conversation_mode';
 
 function getProjectRoot() {
   if (process.env.PROJECT_ROOT) return process.env.PROJECT_ROOT;
@@ -46,17 +45,17 @@ function write(name) {
 
 /**
  * Read the active skill name.
- * Returns FALLBACK when file missing, stale (>60 s), or malformed.
+ * Returns FALLBACK when file missing or malformed. The marker is authoritative
+ * until overwritten — long-running orchestrator turns must not be told they're
+ * in conversation_mode just because a wall-clock window elapsed. Stop hook
+ * clears the marker; SessionStart writes the FALLBACK marker on resume.
  * @returns {string}
  */
 function read() {
   try {
-    const raw  = fs.readFileSync(markerPath(), 'utf8');
-    const obj  = JSON.parse(raw);
-    if (!obj || !obj.ts) return FALLBACK;
-    const age  = Date.now() - Date.parse(obj.ts);
-    if (!Number.isFinite(age) || age > STALENESS_MS) return FALLBACK;
-    return obj.skill || FALLBACK;
+    const raw = fs.readFileSync(markerPath(), 'utf8');
+    const obj = JSON.parse(raw);
+    return (obj && obj.skill) || FALLBACK;
   } catch (_) {
     return FALLBACK;
   }


### PR DESCRIPTION
## Summary

Two architectural fixes from the R-cluster handoff:

- **D6 (#92)** — Register `PreToolUse` / `PostToolUse` / `Stop` in `hooks/hooks.json` with `${CLAUDE_PLUGIN_ROOT}` so routing works on any developer's machine. Local `.claude/settings.json` absolute-path hooks are now redundant and should be removed per-developer (gitignored, not in this diff).
- **R6 (#105)** — SessionStart writes the active-skill marker so the first tool call in a fresh session always reads a valid file. Removes the 60s staleness window from `active-skill.js read()`: a long-running orchestrator turn must not be told it's in `conversation_mode` just because wall-clock elapsed. The marker is authoritative until overwritten.

## Changes

- `hooks/hooks.json` — added `PreToolUse`, `PostToolUse`, `Stop`, and a 2nd `SessionStart` entry pointing at the new `init-marker.js`.
- `scripts/hooks/init-marker.js` — new ~30-line SessionStart hook that writes `{skill: conversation_mode}` to `.claude/.active-skill`.
- `scripts/lib/active-skill.js` — removed `STALENESS_MS` constant; `read()` returns `obj.skill || FALLBACK` without a wall-clock check.

## Test plan

Verified with `routing.enabled=true`:
- [x] T1 main-thread Edit > 100 lines on `building` (code_draft) → BLOCK exit 2
- [x] T2 subagent Edit > 100 lines (agent_id present) → ALLOW exit 0
- [x] T3 main-thread Bash psql → BLOCK universal floor exit 2
- [x] T4 subagent Bash psql → BLOCK universal floor exit 2 (still applies)
- [x] `init-marker.js` writes `{skill: conversation_mode}` on invocation
- [x] 5-hour-old marker now returns its skill instead of falling back
- [x] `claude plugin validate .` passes

Closes #92, closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
