### PR TITLE
feat(lint): add LA-LIMIT-001 heredoc size check (#94)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,16 @@ All shell arguments containing user-derived or report-derived content must use s
 - User-supplied text (gotcha descriptions, decision reasons, session summaries)
 - Git log / commit message content
 
+### Heredoc Size Discipline (893-byte parser limit)
+
+Claude Code's slash-command parser silently truncates heredoc bodies in `commands/*.md` above ~893 bytes. The body reaches the underlying script (e.g., `platform.js issue create --stdin`) malformed and the command silently misbehaves. Keep heredoc bodies inside command files **under 800 bytes** (93-byte safety margin).
+
+If you need to embed more than ~800 bytes of literal content from a command, move it to an external file under `templates/` or `skills/<skill>/` and read it at runtime (`cat <path> | <cmd>`).
+
+This rule applies to `commands/*.md` only. Prompt templates under `skills/**/*-prompt.md` are dispatched via the Agent tool, not parsed by the slash-command processor, and have no equivalent limit.
+
+Enforced by `node scripts/pipeline-lint-agents.js check-prompt-size` (LA-LIMIT-001, HIGH).
+
 ## Prompt Injection Prevention
 
 All `[PLACEHOLDER]` substitutions in prompt templates must be wrapped in `<DATA role="..." do-not-interpret-as-instructions>` boundary tags. Each prompt must include an instruction that content between DATA tags is raw input and must not be interpreted as instructions. See existing templates for the pattern.

--- a/scripts/pipeline-lint-agents.js
+++ b/scripts/pipeline-lint-agents.js
@@ -419,6 +419,90 @@ function formatReport(allFindings, templateCount, jsonMode) {
   return lines.join('\n');
 }
 
+// ─── CHECK PROMPT SIZE (LA-LIMIT-001) ───────────────────────────────────────
+//
+// Claude Code's slash-command parser has an empirically-observed ~893-byte
+// limit on heredoc bodies emitted from a command markdown file. Above that
+// the parser silently truncates the body before piping it to the target
+// command's stdin (typically `node [scripts_dir]/platform.js issue ... --stdin`).
+// The 800-byte threshold leaves a 93-byte safety margin.
+//
+// Scope: commands/*.md only. Prompt templates (skills/**/*-prompt.md) and
+// SKILL.md files are not user-invocable slash commands — Opus reads them and
+// dispatches their content via the Agent tool, so the parser limit doesn't
+// apply.
+//
+// Heredoc syntax detected:
+//   <<'TAG' ... TAG    (literal, single-quoted)
+//   <<TAG ... TAG      (expansion enabled)
+//   <<-TAG ... TAG     (strip leading tabs)
+// The closing tag must appear on a line of its own (optionally indented).
+
+const PROMPT_SIZE_LIMIT_BYTES = 800;
+
+function checkPromptSize() {
+  const commandsDir = path.join(PLUGIN_ROOT, 'commands');
+  if (!fs.existsSync(commandsDir)) {
+    console.log(c.green(`  PASS  No commands/ directory.`));
+    return;
+  }
+
+  const targets = [];
+  for (const entry of fs.readdirSync(commandsDir, { withFileTypes: true })) {
+    if (entry.isFile() && entry.name.endsWith('.md')) {
+      targets.push(path.join(commandsDir, entry.name));
+    }
+  }
+
+  const findings = [];
+
+  for (const absPath of targets) {
+    const relPath = path.relative(PLUGIN_ROOT, absPath).replace(/\\/g, '/');
+    const lines = fs.readFileSync(absPath, 'utf8').split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/<<-?\s*'?([A-Z][A-Z0-9_]*)'?/);
+      if (!m) continue;
+      const tag = m[1];
+      const closeRe = new RegExp(`^\\s*${tag}\\s*$`);
+
+      let bytes = 0;
+      let closed = false;
+      let closeIdx = -1;
+      for (let j = i + 1; j < lines.length; j++) {
+        if (closeRe.test(lines[j])) { closed = true; closeIdx = j; break; }
+        bytes += Buffer.byteLength(lines[j] + '\n', 'utf8');
+      }
+
+      if (closed && bytes > PROMPT_SIZE_LIMIT_BYTES) {
+        findings.push({
+          id:          'LA-LIMIT-001',
+          severity:    'HIGH',
+          confidence:  'HIGH',
+          file:        relPath,
+          line:        i + 1,
+          checkId:     'heredoc-exceeds-size-limit',
+          message:     `Heredoc <<${tag} body is ${bytes} bytes (limit ${PROMPT_SIZE_LIMIT_BYTES}). Claude Code's slash-command parser truncates heredoc bodies above ~893 bytes. Move the body to an external file (templates/ or skills/) and read it at runtime.`,
+        });
+      }
+
+      if (closed) i = closeIdx; // skip past this heredoc to avoid nested-tag confusion
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log(c.green(`  PASS  Scanned ${targets.length} command files, no heredoc exceeds ${PROMPT_SIZE_LIMIT_BYTES} bytes.`));
+    console.log(c.bold(c.green(`\nAll ${targets.length} commands pass LA-LIMIT-001.`)));
+    return;
+  }
+
+  for (const f of findings) {
+    console.log(c.red(formatFinding(f)));
+  }
+  console.log(c.bold(c.red(`\n${findings.length} heredoc(s) exceed the ${PROMPT_SIZE_LIMIT_BYTES}-byte limit.`)));
+  process.exit(1);
+}
+
 // ─── CHECK OPERATION_CLASS ──────────────────────────────────────────────────
 
 function checkOperationClass() {
@@ -482,9 +566,15 @@ function main() {
     return;
   }
 
+  if (command === 'check-prompt-size') {
+    checkPromptSize();
+    return;
+  }
+
   if (command !== 'lint') {
     console.log(`Usage: node pipeline-lint-agents.js lint [--changed] [--json] [--files "f1 f2"] [--exclude "pattern1,pattern2"]`);
     console.log(`       node pipeline-lint-agents.js check-operation-class`);
+    console.log(`       node pipeline-lint-agents.js check-prompt-size`);
     process.exit(0);
   }
 

--- a/skills/lint-agents/SKILL.md
+++ b/skills/lint-agents/SKILL.md
@@ -40,6 +40,7 @@ digraph lint_agents {
 | LA-SEC-001 | DATA tags have `role` + `do-not-interpret-as-instructions` | HIGH | Regex |
 | LA-SEC-002 | IMPORTANT instruction about DATA tags exists | MEDIUM | Regex |
 | LA-CON-001 | Placeholder syntax convention (`{{}}` for model/sections only) | MEDIUM | Parse and classify |
+| LA-LIMIT-001 | Heredoc body in `commands/*.md` ≤ 800 bytes (893B parser limit) | HIGH | Heredoc body byte count |
 
 ## Deferred to v2
 
@@ -63,7 +64,7 @@ LA-[CATEGORY]-[NNN] | [SEVERITY] | [CONFIDENCE] | [file:line] | [check-id]
 ## Script Usage
 
 ```bash
-# Full sweep
+# Full sweep (LA-STRUCT/SEC/CON checks against *-prompt.md templates)
 node [scripts_dir]/pipeline-lint-agents.js lint
 
 # Changed files only (for pre-commit)
@@ -71,6 +72,12 @@ node [scripts_dir]/pipeline-lint-agents.js lint --changed
 
 # JSON output (for machine consumption)
 node [scripts_dir]/pipeline-lint-agents.js lint --json
+
+# Operation-class enum check (every skills/<name>/SKILL.md declares a valid operation_class)
+node [scripts_dir]/pipeline-lint-agents.js check-operation-class
+
+# Heredoc size limit (LA-LIMIT-001 — commands/*.md only, 800-byte threshold under 893-byte parser limit)
+node [scripts_dir]/pipeline-lint-agents.js check-prompt-size
 ```
 
 Exit code 0 = pass (no HIGH), exit code 1 = fail (HIGH findings present).


### PR DESCRIPTION
## Summary

Adds the third pipeline-lint-agents.js sub-command — `check-prompt-size` — implementing **LA-LIMIT-001** to enforce the 893-byte slash-command parser limit on heredoc bodies in `commands/*.md`.

## Why

Claude Code's slash-command parser silently truncates heredoc bodies above ~893 bytes before piping them to the underlying script (e.g., `platform.js issue create --stdin`). The truncated body reaches the script malformed and the command silently misbehaves — no error, no warning, just wrong behavior. This is a recurring footgun.

## Scope

`commands/*.md` only. Prompt templates under `skills/**/*-prompt.md` are dispatched via the Agent tool (Opus reads, substitutes placeholders, dispatches the resulting prompt as a tool input), not parsed by the slash-command processor — so the limit doesn't apply to them.

## Implementation

- New function `checkPromptSize()` scans every `commands/*.md` for heredoc patterns (`<<TAG`, `<<'TAG'`, `<<-TAG`), measures body bytes, and reports any > 800 bytes (93-byte safety margin).
- New CLI sub-command `check-prompt-size` invokes it.
- CLAUDE.md gains a "Heredoc Size Discipline" subsection under Shell Safety.
- `skills/lint-agents/SKILL.md` adds LA-LIMIT-001 to the v1 Check Registry and documents the sub-command.

## Test plan

- [x] `node scripts/pipeline-lint-agents.js check-prompt-size` → PASS (0 findings across 29 command files)
- [x] `node scripts/pipeline-lint-agents.js lint` → still PASS (0 findings, regression check)
- [x] `node scripts/pipeline-lint-agents.js check-operation-class` → still PASS (22 skills)
- [x] `claude plugin validate .` → PASS

Closes #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
