### PR TITLE
chore(gitignore): exclude DECISIONS.md (Postgres is canonical)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ worktrees/
 .claude/.active-skill
 .claude/settings.json
 .scratch/
+DECISIONS.md


### PR DESCRIPTION
## Summary

Gitignore `DECISIONS.md`. The file was being created at repo root by `scripts/pipeline-files.js decision` as an append-only artifact, but Postgres is the canonical decision store (per CLAUDE.md three-store hierarchy). The on-disk file was the worst-of-both-worlds: tracked location, never committed, drift between contributors.

## Test plan

- [x] `git status` no longer shows `DECISIONS.md` as untracked after `pipeline-files.js decision` runs.
