### PR TITLE
feat(memory): chunker + loader for high-fidelity semantic memory retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to Pipeline are documented here. Format follows [Keep a Chan
 
 ## [Unreleased]
 
+### Added
+
+- **Chunker / loader for high-fidelity semantic memory retrieval** — `scripts/pipeline-chunker.js` (boundary-aware text splitter with per-source token-budget calibration) and `scripts/pipeline-memory-loader.js` (CLI loader for `memory_entries`, `session_chunks`, and `policy_sections` with SHA256 content_hash idempotence, BATCH=8 per-chunk error isolation, and Windows-aware `~/.claude/projects/<encoded-cwd>/` path computation). Closes the gap that left these three tables permanently empty in real projects (verified live: 690 chunks embedded, 0 errors). Schema additions: `memory_entry_chunks` sibling table, `policy_sections.chunk_idx`, `content_hash` columns on all three chunk tables, HNSW vector indexes, and the `v_memory_hits` unified search view. `cmdHybrid` and `cmdSearch` query the view as a unified section with chunk-position indicators. Acceptance tests in `scripts/test-chunker.js` (5/5 pass against pathological inputs from spec §6). Issue #142, Postgres task #60.
+
 ## [0.3.0-alpha] — 2026-04-25
 
 This release focuses on three areas: Windows safety hardening across the init, orientation, and finish commands (replacing POSIX bash blocks with Node scripts that use `execFileSync` argv arrays throughout); per-feature token tracking via transcript mining (new `scripts/pipeline-cost.js` helper and `feature_token_usage` Postgres table); and inter-session memory handling, where semantic recall now covers the full knowledge tier — decisions, sessions, gotchas, and six new memory-surface tables (memory_entries, session_chunks, policy_sections, checklist_items, incidents, corpus_files) are all wired into the hybrid search path, an `options.num_ctx` knob prevents Ollama from pre-truncating long inputs, and the embedder now gracefully skips tables that exist on paper but have not yet been populated by a loader.

--- a/docs/findings/debate-2026-04-26-chunking-loader.md
+++ b/docs/findings/debate-2026-04-26-chunking-loader.md
@@ -1,0 +1,136 @@
+---
+debate_date: 2026-04-26
+spec: docs/specs/2026-04-26-chunking-loader-spec.md
+github_issue: 142
+postgres_task: 60
+panelists: [advocate, skeptic, practitioner]
+disposition: proceed-with-constraints
+---
+
+# Debate Verdict: Chunker / Loader for Semantic Memory
+
+## Disposition: proceed-with-constraints
+
+The chunker/loader architecture is fundamentally sound. Boundary-aware splitting, per-chunk error isolation, idempotent upsert, and a unified query view are the correct primitives for making semantic memory functional after it has been non-operational since launch. Four HIGH-likelihood correctness gaps surfaced across the three panels — char-heuristic failure on JSONL content that causes silent token overruns, a missing HNSW vector index that degrades cosine query performance to sequential scans, Ollama returning HTTP 200 with an empty embedding array that poisons cosine rankings silently, and Windows encoded-cwd path computation that discovers zero JSONL files — any one of which would leave semantic memory either non-functional or silently corrupt in production. The plan must resolve all four before merge. The remaining contested points require explicit choices by the plan author but do not block the architecture.
+
+## Points of Agreement
+
+These items received explicit endorsement from two or more panelists and are hard constraints. The plan must not violate them.
+
+- **Chunking is load-bearing regardless of embedder.** Even bge-m3's 8192-token ceiling cannot eliminate the need to split long session transcripts into retrieval units. A single tool_result block from a large file read can exceed 10,000 tokens. Strategy B (embedder swap) is a bounded follow-on, not an alternative, and must be treated as such in the plan. (Advocate, Skeptic by non-contestation, Practitioner)
+
+- **Boundary priority order heading → code-fence → paragraph → sentence → hard-split is correct.** This mirrors the actual structure of CLAUDE.md and JSONL content and matches LangChain MarkdownTextSplitter production behavior. Fixed-window chunking would routinely bisect fenced code blocks and heading sections. Any plan that reorders these rules must provide empirical justification from a test run against the pathological inputs in §6. (Advocate, Practitioner)
+
+- **BATCH=8 with per-chunk error isolation is the right blast-radius control.** The prior BATCH=32 silent-discard failure mode (cmdIndex) is the direct precedent. Reducing to BATCH=8 limits blast radius 4x and enables chunk-identity logging on failure. LlamaIndex OllamaEmbedding uses BATCH=10; BATCH=8 is in the correct range. Continue-on-error with logged chunk identity is standard practice. (Advocate, Practitioner)
+
+- **chunkText() must remain pure and table-agnostic.** Context prefix injection belongs in the loader, not in the chunker. The plan must not couple chunk construction to any specific table's schema. Any function that requires a table name to compute chunk boundaries has violated this constraint. (Advocate — hard constraint, uncontested)
+
+- **The five §6 acceptance gate tests must cover pathological inputs, not happy paths.** The oversized JSONL block, code-fence bisection, idempotent re-run, Windows path round-trip, and non-ASCII Ollama response are exactly the failure modes that broke prior implementations. Happy-path tests validate nothing the prior implementation did not already handle. (Advocate, Practitioner)
+
+- **Implementation must follow §7 order: chunker → migration → loader → embed view.** Out-of-order implementation creates dependency failures. The migration must exist before the loader runs; the view must exist before agents query it. No plan deliverable may skip a step or reorder them without a dependency analysis. (Advocate, uncontested)
+
+- **Semantic memory is currently non-functional and this spec is the minimum viable intervention.** Zero rows in memory_entry_chunks, session_chunks, and policy_sections since launch. No panelist argued for deferral of the entire feature. The debate result is proceed-with-constraints, not rethink. (All three panelists)
+
+- **v_memory_hits must be created in the embed setup path, not post-loader.** The view must exist before any agent queries it. Including it in the post-loader migration creates a window where agents receive errors on memory queries if the loader has not yet run. (Advocate, implied by Practitioner's HNSW index placement recommendation)
+
+## Contested Points
+
+### CP1 — v_memory_hits: SQL view vs. JS UNION ALL
+
+**View (Advocate):** The SQL view enforces a single query surface so agents cannot bypass chunk-level content by querying source tables directly. The consistency guarantee is worth the schema complexity.
+
+**JS UNION ALL (Skeptic):** parent_id is semantically incoherent across the three source tables: memory_entry_chunks.parent_id is a row ID, session_chunks.parent_id is a session ordinal (sessions.num — a different concept), and policy_sections.parent_id is a self-referential row ID. Any caller using parent_id for grouping or linkage receives incompatible integers depending on source_table. The view masks this type mismatch; a JS-constructed UNION ALL allows per-source aliasing that resolves it transparently.
+
+**Recommendation for the plan:** Keep the SQL view but surface the mismatch explicitly rather than masking it. Add source_row_id (consistent row ID in each source table) and source_ordinal (session_num for session_chunks, NULL elsewhere) as explicit columns alongside parent_id. Document parent_id as display-only in the view comment. Callers needing reliable row linkage must use source_row_id. This preserves the single-query-surface guarantee while eliminating the silent type mismatch.
+
+### CP2 — Idempotence strategy: unconditional embedding = NULL reset vs. content-hash skip
+
+**Unconditional reset (Advocate):** Simple, correct, guarantees fresh embeddings on every re-run. A content-hash approach adds schema complexity and a migration.
+
+**Content-hash skip (Skeptic):** For 1700+ chunks, unconditional reset causes 30+ seconds of unnecessary Ollama inference on every incremental loader run. Every call to the loader becomes a full rebuild costing 30+ seconds regardless of whether source content changed. This makes the loader unusable as a routine incremental sync tool. SHA256 content_hash costs one migration column per chunk table and one hash comparison per upsert.
+
+**Recommendation for the plan:** Add SHA256 content_hash column to all three chunk tables in the §5.3 migration. The loader computes the hash of source text before upsert and skips the Ollama call when the stored hash matches. Retain unconditional reset as a --force flag for full rebuilds when a model change or schema migration invalidates all embeddings. This makes the loader usable as both a routine incremental sync and a full rebuild, and it costs one migration and approximately ten lines of JS.
+
+### CP3 — Acceptance gate automation: test script vs. manual checklist
+
+**Manual (Advocate):** §6 tests are well-specified; a competent implementer can run them manually. Gate enforcement is the plan author's responsibility.
+
+**Automated (Skeptic):** A hard gate with no test runner, no script, and no CI hook is a naming convention. "Hard merge gate" without an automated check means the gate will be skipped under time pressure. The four prior zero-row tables are evidence that manual quality gates fail in this codebase.
+
+**Recommendation for the plan:** Add scripts/test-chunker.js covering all five §6 cases as runnable automated tests. The script must exit 0 on pass and 1 on failure. Gate enforcement requires a logged passing run output in the PR description before any merge. Full CI integration can follow as a separate task; the script must exist and pass at v1.
+
+### CP4 — v_memory_hits snippet length and chunk position metadata
+
+**Status quo (implicit in spec):** Snippet at 120 chars, no chunk position indicator.
+
+**Extended (Skeptic / Practitioner):** Production retrieval UIs surface 200-400 chars of snippet. Callers have no way to determine whether a returned chunk is the first or fifteenth in a sequence without chunk_idx and total_chunks, which are necessary for accurate context reconstruction.
+
+**Recommendation for the plan:** Extend snippet to 300 chars in the view DDL. Add chunk_idx and total_chunks as computed columns via subquery on each chunk table grouped by source row. Both changes are view-DDL only and do not touch the embedding pipeline or chunker.
+
+## Invalidated Assumptions
+
+**1. "A 1400-char ceiling provides a 30% safety margin for the 512-token cap."**
+The spec assumes 4 chars/token uniformly across all source tables, yielding a 1400-char ceiling with 30% margin below the 512-token embed model limit. Skeptic refuted with direct evidence: Claude Code JSONL transcripts contain JSON-escaped strings, code inside tool_result blocks, and URL-dense content that averages 2-2.5 chars/token, not 4. A 1400-char chunk of a session tool_result is 560-700 tokens — 10-37% over the cap. The 30% safety margin disappears precisely on session_chunks, the table that motivated the chunking feature. The loader silently skips oversize chunks with the same token-overrun error the prior implementation produced. The plan must implement per-source chars-per-token calibration: JSONL sources use a 560-char ceiling (2.5 chars/token); prose sources retain the 1400-char ceiling (4.0 chars/token). The caller (loader) selects mode by source table name. chunkText() receives the ceiling as a parameter, not a hardcoded constant.
+
+**2. "The GIN index on fts_vec is sufficient for retrieval performance."**
+The spec creates a GIN index on fts_vec for full-text search but specifies no vector index on the embedding column. Practitioner refuted with standard pgvector behavior: without CREATE INDEX USING hnsw (embedding vector_cosine_ops) on memory_entry_chunks.embedding, every cosine similarity query performs a sequential scan over all chunk rows. At 5000+ chunks — readily reached after a few weeks of session history — this is a hard latency regression on every agent memory lookup. The HNSW index is not optional performance tuning; it is a correctness requirement for usable retrieval at realistic data volumes. The plan must add HNSW indexes on memory_entry_chunks.embedding and session_chunks.embedding in the §5.3 migration.
+
+**3. "§6 constitutes a hard merge gate."**
+The spec labels five tests a hard merge gate with no test runner, no automation path, and no CI hook attached. Skeptic refuted the assumption that the gate label is self-enforcing: a gate without an automated check is a naming convention. The evidence is the semantic memory tables themselves — they have been non-functional since launch, implying prior quality gates were insufficient. The plan must ship scripts/test-chunker.js alongside the chunker and require a passing run before merge.
+
+**4. "ollamaEmbed can detect failure via HTTP status code."**
+Pre-0.3.0 Ollama returns HTTP 200 with an empty embedding array (not an error status) when processing certain repeated non-ASCII inputs. The spec's Test 5 targets this scenario but does not specify that ollamaEmbed must check array content rather than only HTTP status. Practitioner refuted via Ollama release history. If ollamaEmbed checks only for non-200, it silently writes a zero-vector (or writes no row with no logged error depending on implementation) to the chunk table. A zero-vector embedding poisons all cosine rankings: the chunk's distance to every query vector becomes near-1.0, causing it to surface in every retrieval regardless of semantic relevance. The plan must validate that the returned embedding array is non-empty and that its Euclidean magnitude is non-zero before writing. Log the chunk identity and skip on failure; never write a zero-vector.
+
+**5. "JSONL path computation is cross-platform."**
+The spec describes loading session JSONL from ~/.claude/projects/<encoded-cwd>/ without specifying encoding rules per platform. Practitioner refuted with Claude Code internals: on Windows, the cwd encoding uses backslash-to-dash substitution, producing a directory name that no POSIX-rule path computation resolves. The loader discovers zero JSONL files silently on Windows — the same outcome as if session_chunks were empty, with no error surfaced. The plan must abstract encoded-cwd path computation into scripts/lib/encoded-cwd.js that branches on process.platform, and cover it with a path round-trip unit test in scripts/test-chunker.js.
+
+## Risk Register
+
+| Risk | Source | Likelihood | Mitigation the plan must include |
+|------|--------|------------|----------------------------------|
+| Char heuristic at 4 chars/token overflows the 512-token embed cap on JSONL tool_result blocks (real density: 2-2.5 chars/token, producing 560-700 token chunks) | Skeptic | HIGH | Per-source calibration: JSONL ceiling 560 chars (2.5 chars/token), prose ceiling 1400 chars (4.0 chars/token); loader selects mode by source table; chunkText() receives ceiling as a parameter |
+| Missing HNSW vector index causes sequential cosine scans on memory_entry_chunks.embedding; latency regression at 5000+ chunks makes agent memory lookups unusable | Practitioner | HIGH | Add CREATE INDEX USING hnsw (embedding vector_cosine_ops) on memory_entry_chunks.embedding and session_chunks.embedding in §5.3 migration |
+| Pre-0.3.0 Ollama returns HTTP 200 with empty embedding array for repeated non-ASCII input; ollamaEmbed writes zero-vector, poisoning all cosine rankings silently | Practitioner | HIGH | ollamaEmbed must assert returned array is non-empty and has non-zero magnitude before write; log chunk identity and skip on failure; include assertion in Test 5 of scripts/test-chunker.js |
+| Windows encoded-cwd path computation (POSIX rules applied to backslash-to-dash Windows encoding) finds zero JSONL files with no error surfaced | Practitioner | HIGH | Abstract to scripts/lib/encoded-cwd.js; branch on process.platform === 'win32'; cover with path round-trip unit test |
+| Unconditional embedding = NULL reset makes every loader invocation a 30+ second full rebuild for 1700+ chunks; loader is unusable as incremental sync | Skeptic | MEDIUM | Add SHA256 content_hash column to chunk tables; skip embed when hash matches stored value; --force flag for full rebuild |
+| Rule-5 hard-split fallback fires on JSONL tool_result content, bisecting mid-expression at sentence boundaries inside code blocks | Practitioner | MEDIUM | Detect tool_result message type from JSONL entry structure; apply code-fence (rule 2) as primary split boundary for tool_result content; sentence rule (rule 4) applies to prose types only |
+| parent_id type mismatch in v_memory_hits (row ID vs. session ordinal vs. self-referential row ID) misleads callers grouping chunks across source tables | Skeptic | MEDIUM | Add source_row_id and source_ordinal columns; document parent_id as display-only; callers use source_row_id for reliable linkage |
+| Rule-5 hard-split fallback produces chunks with no overlap re-seeding, violating the 50-token overlap contract established by rules 1-4 | Practitioner | LOW | When rule-5 fires, carry the last 50-token window of the prior chunk as seed for the next split boundary; matches the overlap contract of boundary-rule splits |
+
+## Plan Must
+
+1. **Implement per-source chars-per-token calibration in chunkText()**: Accept a charsPerToken parameter from the caller (loader). JSONL sources pass 2.5 (560-char ceiling); prose sources pass 4.0 (1400-char ceiling). chunkText() must not hardcode 4.0. The loader selects mode by source table name at call time. This is the minimum fix to prevent silent token overruns on session_chunks, the primary motivation for the feature.
+
+2. **Add HNSW vector index to §5.3 migration for memory_entry_chunks and session_chunks**: CREATE INDEX USING hnsw (embedding vector_cosine_ops) on each table's embedding column. Without this, cosine similarity queries perform sequential scans. At realistic data volumes (5000+ chunks after several weeks of use) this causes latency that renders agent memory lookups unusable. Include index creation in the same migration that adds the chunk tables.
+
+3. **Validate Ollama response array before writing embedding**: ollamaEmbed must check that the returned array is non-empty and that its Euclidean magnitude is non-zero. On failure, log the chunk_id and source_table and skip the row — never write a zero-vector. Include this validation as a required assertion in Test 5 of scripts/test-chunker.js.
+
+4. **Abstract encoded-cwd path computation into scripts/lib/encoded-cwd.js**: Implement platform detection via process.platform === 'win32' and apply the correct cwd encoding for each platform. All JSONL discovery paths in the loader must import from this utility. No inline platform branching in the loader or chunker. Add a path round-trip unit test to scripts/test-chunker.js.
+
+5. **Add SHA256 content_hash column to all three chunk tables in §5.3 migration**: The loader computes hash of source text before upsert. When the stored hash matches, skip the Ollama call and do not reset embedding to NULL. Provide a --force flag to bypass hash checking for full rebuilds (e.g., after a model change). This makes the loader viable as a routine incremental sync tool, not just a full rebuild.
+
+6. **Detect tool_result message type in JSONL loader and apply code-fence boundary as primary rule**: Parse the JSONL entry structure to identify tool_result content. For tool_result content, apply rule-2 (code-fence boundary) as the primary split rule before falling through to rule-4 (sentence boundary). Sentence splitting must not fire on code inside tool_result blocks. This prevents mid-expression splits on the highest-volume source content type.
+
+7. **Extend v_memory_hits snippet to 300 chars and add chunk_idx, total_chunks, source_row_id, and source_ordinal**: snippet at 120 chars is below the production minimum for retrieval UIs. chunk_idx and total_chunks enable callers to reconstruct sequence context. source_row_id provides reliable cross-source linkage; source_ordinal exposes session_num for session_chunks. All changes are in the view DDL only and do not affect the embedding pipeline.
+
+8. **Add scripts/test-chunker.js covering all five §6 pathological cases as automated tests**: Test 1: oversized single JSONL block split correctly with per-source ceiling. Test 2: code-fence not bisected by boundary rules. Test 3: idempotent re-run produces no duplicate rows and respects content_hash skip. Test 4: Windows encoded-cwd path round-trip resolves correctly on all platforms. Test 5: Ollama empty-array response does not write a zero-vector; row is skipped and logged. Script must exit 0 on pass and exit 1 on any failure with a descriptive message.
+
+9. **Gate merge on passing scripts/test-chunker.js run**: PR description must include logged output of node scripts/test-chunker.js with exit 0 before any merge request is opened. This converts the §6 "hard merge gate" from a naming convention into an enforced checkpoint.
+
+10. **Re-seed 50-token overlap after rule-5 hard-split**: When the hard-split fallback fires, carry the last 50-token window of the prior chunk as the seed for the next split boundary. This matches the overlap contract established by the boundary-rule splits (rules 1-4) and prevents information loss at hard-cut boundaries in long content blocks.
+
+11. **Create v_memory_hits in the §5.3 setup migration, not post-loader**: The view must exist before any agent attempts a memory query. Including it in a post-loader migration creates a gap where agents receive query errors if the loader has not yet run. The view DDL is independent of loader state; include it in the same migration that creates the chunk tables.
+
+12. **Document parent_id as display-only in v_memory_hits**: Add a SQL comment on the view explaining that parent_id semantics differ by source_table (row ID for memory_entry_chunks and policy_sections, session ordinal for session_chunks). Callers requiring reliable row linkage must use source_row_id. This prevents silent bugs in any downstream code that treats parent_id as a homogeneous foreign key.
+
+## Recommended Deferrals
+
+- **Strategy B embedder swap (bge-m3)**: The architecture is a bounded follow-on once session_chunks is populated and the HNSW index is in place. No blocker in the current spec — defer to a standalone spec after this one ships and baseline retrieval quality is established.
+
+- **Per-table batch size configuration**: BATCH=8 is acceptable for all three tables at v1 scale. policy_sections entries are short-by-construction and rarely need isolation, making larger batches a reasonable optimization there. Per-table batch config is three lines of code but zero correctness value until profiling data from production use exists.
+
+- **Weekly aggregation reporting on chunk-level embed failures**: The per-chunk error log from BATCH=8 error isolation already captures the raw signal. Aggregating into a weekly report belongs after the loader has shipped and produced real failure data. Adding it now would be instrumenting a path that may not fail in practice.
+
+- **Full-text search integration with v_memory_hits**: The GIN index on fts_vec supports full-text queries, but the loader and chunk tables do not yet populate tsvector columns consistently across all three source tables. Integrating FTS with the semantic retrieval path is a separate feature; it belongs after cosine retrieval is verified working and delivering value.
+
+- **BATCH=8 adjustment for policy_sections**: Short-by-construction sections make per-chunk error isolation less valuable for that specific table. Tuning batch size per table is a legitimate optimization but adds configuration surface area that has no correctness impact at v1 scale.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -59,12 +59,12 @@ These six tables were added in 0.3.0-alpha. The schema and embedder are fully wi
 
 | Table | Purpose | Primary text fields (embedding input) | Populator |
 |-------|---------|--------------------------------------|-----------|
-| `memory_entries` | Auto-memory entries — mirrors `~/.claude/projects/<encoded-cwd>/memory/*.md` | `"Memory: {name}\n{description}\n\n{body[0:5000]}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
-| `session_chunks` | Chunked Claude Code session transcripts for semantic recall | `"Session {session_num} {chunk_kind}: {content}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
-| `policy_sections` | Policy/standards docs (CLAUDE.md, etc.) broken into addressable sections | `"Policy: {doc_id} {section_num}: {section_title}\n\n{content}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
-| `checklist_items` | Process checklists at known cadences (pre-commit, release-prep, etc.) | `"Checklist: {checklist_name} [{cadence}]: {title}\n{description}\n{verification_step}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
-| `incidents` | Post-incident notes (`incident_code`, `what_happened`, `what_we_did`, `watch_for`) | `"Incident: {incident_code}: {title}\nWhat happened: {what_happened}\nWhat we did: {what_we_did}\nWatch for: {watch_for}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
-| `corpus_files` | Arbitrary file corpus (PDFs, docs, summaries) for grounded retrieval | `"File: {path}\nDomain: {source_domain}\n\n{summary}"` | User-provided loader (no in-plugin loader shipped — epic #109) |
+| `memory_entries` | Auto-memory entries — mirrors `~/.claude/projects/<encoded-cwd>/memory/*.md` | `"Memory: {name}\n{description}\n\n{body[0:5000]}"` | `node scripts/pipeline-memory-loader.js memory` |
+| `session_chunks` | Chunked Claude Code session transcripts for semantic recall | `"Session {session_num} {chunk_kind}: {content}"` | `node scripts/pipeline-memory-loader.js sessions` |
+| `policy_sections` | Policy/standards docs (CLAUDE.md, etc.) broken into addressable sections | `"Policy: {doc_id} {section_num}: {section_title}\n\n{content}"` | `node scripts/pipeline-memory-loader.js policy` |
+| `checklist_items` | Process checklists at known cadences (pre-commit, release-prep, etc.) | `"Checklist: {checklist_name} [{cadence}]: {title}\n{description}\n{verification_step}"` | User-provided loader (deferred to follow-up epic — see #142 for the three shipped loaders) |
+| `incidents` | Post-incident notes (`incident_code`, `what_happened`, `what_we_did`, `watch_for`) | `"Incident: {incident_code}: {title}\nWhat happened: {what_happened}\nWhat we did: {what_we_did}\nWatch for: {watch_for}"` | User-provided loader (deferred to follow-up epic — see #142 for the three shipped loaders) |
+| `corpus_files` | Arbitrary file corpus (PDFs, docs, summaries) for grounded retrieval | `"File: {path}\nDomain: {source_domain}\n\n{summary}"` | User-provided loader (deferred to follow-up epic — see #142 for the three shipped loaders) |
 
 ---
 
@@ -245,15 +245,26 @@ node scripts/pipeline-embed.js hybrid "destructive operation guard"
 
 ### Loader status
 
-**Pipeline does not ship a loader for these six tables.** What's shipped is the schema (the six `CREATE TABLE` blocks in `setup-knowledge-db.sql`) and the embedder support (the six rows in `pipeline-embed.js`'s `TABLES` array). Anything that populates the tables — files synced into rows, transcripts chunked, policy docs sectioned — is up to the user.
+Pipeline ships loaders for three of the six inter-session memory tables: `memory_entries`, `session_chunks`, and `policy_sections`. The other three (`checklist_items`, `incidents`, `corpus_files`) remain user-provided.
 
-A user-written loader would, broadly, need to:
+The shipped loader is `scripts/pipeline-memory-loader.js`. It reads from filesystem sources, chunks via `scripts/pipeline-chunker.js` to respect `mxbai-embed-large`'s 512-token cap, computes SHA256 content hashes for incremental sync, and embeds in BATCH=8 with per-chunk error isolation:
 
-1. Read its sources (files from `memory/`, session JSONL, policy docs, checklists, etc.) — the exact protocol depends on the source.
-2. Upsert rows into the relevant tables — schema is at `scripts/setup-knowledge-db.sql`.
-3. Either embed inline (call Ollama directly) or rely on the next `pipeline-embed.js index` run.
+| Subcommand | Source | Chunk ceiling |
+|------------|--------|---------------|
+| `memory`   | `~/.claude/projects/<encoded-cwd>/memory/*.md` | 1400 chars (prose) |
+| `sessions` | `~/.claude/projects/<encoded-cwd>/*.jsonl`     | 560 chars (JSONL/tool_result) |
+| `policy`   | project + global `CLAUDE.md`                   | 1400 chars (prose) |
+| `all`      | All three in sequence                          | per-source above |
 
-Whether to ship an opinionated loader inside Pipeline — and if so, what protocol it would follow — is tracked as a design question under epic #109, not a port-existing-code task. Tables remain empty in projects without a loader; `cmdHybrid`'s defensive guards mean the empty tables are silently skipped.
+Flags: `--force` (bypass content_hash skip), `--dry-run` (compute chunks, skip DB writes).
+
+Idempotence: re-running with no source change makes zero Ollama calls. Adding a new memory file or session JSONL embeds only the new content; unchanged rows are skipped via `content_hash` match.
+
+Search across the three loaded tables uses the unified view `v_memory_hits` and surfaces in `node scripts/pipeline-embed.js hybrid` and `... search` commands as a single section labeled "memory (chunked: memory + sessions + policy)" with `[source_table]` prefixes and `chunk N/M` position indicators.
+
+A loader for the remaining three tables (`checklist_items`, `incidents`, `corpus_files`) is deferred — these tables have no natural filesystem source-of-truth; they are populated by pipeline workflow commands rather than file mirrors.
+
+The corresponding embedder swap to a longer-context model (e.g., `bge-m3`) is tracked as Strategy B follow-up and is intentionally out of scope of the chunker/loader release.
 
 ---
 

--- a/docs/plans/2026-04-26-chunker-loader-plan.md
+++ b/docs/plans/2026-04-26-chunker-loader-plan.md
@@ -1,0 +1,561 @@
+# Chunker / Loader Implementation Plan
+
+> **For agentic workers:** Use /pipeline:build to implement this plan task-by-task.
+> Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `scripts/pipeline-chunker.js` and `scripts/pipeline-memory-loader.js` to eliminate Ollama token-overrun failures and achieve 100% embedding coverage on `memory_entries`, `policy_sections`, and `session_chunks`.
+
+**Architecture:** A pure-function chunker (boundary-aware, token-budget parameterized) is consumed by a CLI loader that sources rows from the filesystem, chunks them, embeds via `ollamaEmbed()` in BATCH=8, and upserts idempotently. A unified SQL view (`v_memory_hits`) surfaces all three chunk tables through a single query surface for `cmdHybrid`. Encoded-cwd path computation is extracted to a shared utility to handle Windows backslash-to-dash encoding.
+
+**Tech Stack:** Node.js, `scripts/lib/shared.js` (`ollamaEmbed`, `connect`, `loadConfig`), pgvector (HNSW), `crypto` (SHA256), `fs`/`path`/`os` (filesystem sources).
+
+**Model Routing:** Chunker, loader, and test script are `code_draft` (qwen2.5-coder:32b if available, else sonnet). Doc updates are `short_draft` (qwen2.5:14b if available, else haiku). Plan reviewer is sonnet.
+
+**Decisions:** Inline — see Architectural Constraints below.
+
+**Branch:** `feat/chunker-loader-issue-60` | **Issue:** #142 | **Postgres task:** #60
+
+---
+
+## Architectural Constraints
+
+Pulled from the debate verdict "Points of Agreement" and "Plan Must" items. Every task in this plan must comply. Any deviation requires an explicit decision record.
+
+- Chunking is load-bearing regardless of embedder. Strategy B (bge-m3 swap) is a bounded follow-on, not an alternative. Do not conflate the two.
+- Boundary priority order is fixed: heading → code-fence → paragraph → sentence → hard-split. Any reordering requires empirical test evidence from §6 pathological inputs.
+- BATCH=8 with per-chunk error isolation (continue-on-error, log chunk identity) is required. BATCH=32 is the failure precedent.
+- `chunkText()` must remain pure and table-agnostic. Context prefix injection belongs in the loader. No table name may appear in the chunker.
+- The five §6 acceptance gate tests must cover pathological inputs; happy-path tests do not satisfy the gate.
+- Implementation follows §7 order: chunker → migration → loader → embed view. Out-of-order implementation creates dependency failures.
+- `v_memory_hits` must be created in the schema setup path, not post-loader. The view must exist before any agent queries it.
+- `ollamaEmbed` must assert the returned embedding array is non-empty and has non-zero Euclidean magnitude before writing. Zero-vectors poison cosine rankings.
+- HNSW vector index is required on `memory_entry_chunks.embedding` and `session_chunks.embedding`. Without it, cosine queries perform sequential scans at 5000+ chunks — a hard latency regression.
+- Encoded-cwd path computation must live in `scripts/lib/encoded-cwd.js`, branch on `process.platform === 'win32'`, and be unit-tested with a path round-trip test. No inline platform branching in the loader.
+
+### Decisions for This Feature
+
+- **DECISION-001 — v_memory_hits scope:** SQL view kept over JS UNION ALL. Add explicit `source_row_id` (consistent row ID in each source table) and `source_ordinal` (session_num for session_chunks, NULL elsewhere) columns to resolve the parent_id semantic incoherence identified by Skeptic (verdict CP1). `parent_id` is documented as display-only in a SQL view comment. Callers requiring reliable row linkage must use `source_row_id`. Invalidate if: a caller demonstrates a case where `source_row_id` is still ambiguous across source tables.
+
+- **DECISION-002 — Idempotence strategy:** SHA256 `content_hash` column on all three chunk tables. Loader computes hash of source text before upsert; skips the Ollama call when stored hash matches. `--force` flag bypasses hash checking for full rebuilds (e.g., after model change). Unconditional `embedding = NULL` reset is not used as default because 1700+ chunks make every invocation a 30-second full rebuild (verdict CP2). Invalidate if: content_hash produces incorrect cache hits due to non-deterministic source text construction.
+
+- **DECISION-003 — Acceptance gate:** `scripts/test-chunker.js` ships alongside the chunker and automates all five §6 tests (verdict CP3). Script must exit 0 on pass and 1 on any failure. A logged passing-run output is required in the PR description before any merge request is opened. Full CI hook is deferred but the script must exist and pass at v1. Invalidate if: CI integration supersedes the manual run requirement before PR open.
+
+- **DECISION-004 — Per-source token calibration:** `chunkText()` accepts a ceiling parameter (chars). Loader passes 560 chars for JSONL sources (2.5 chars/token — validated by Skeptic with dense JSON/code content in tool_result blocks) and 1400 chars for prose sources (4.0 chars/token). The 1400-char ceiling with 30% margin does not hold for JSONL; the verdict invalidated this assumption for session_chunks (verdict "Invalidated Assumptions" §1). Invalidate if: empirical testing shows JSONL tool_result blocks average closer to 3.5 chars/token, permitting a higher ceiling.
+
+---
+
+## Phase 1: Chunker
+
+**Files:** Create `scripts/pipeline-chunker.js`
+**Model:** code_draft | **TDD:** required
+
+### Task 1.1: Scaffold `chunkText()` with parameter signature
+
+- [ ] Create `scripts/pipeline-chunker.js` with the exported interface:
+  ```js
+  // scripts/pipeline-chunker.js
+  'use strict';
+  function chunkText(text, ceilingChars = 1400) {
+    // returns Array<{ content: string, chunkIdx: number }>
+  }
+  module.exports = { chunkText };
+  ```
+- [ ] Add Node `assert` import at top for inline unit tests.
+- [ ] Verify file is syntactically valid: `node -e "require('./scripts/pipeline-chunker.js')"`
+
+### Task 1.2: Implement boundary rule 1 — markdown heading split
+
+- [ ] Inside `chunkText()`, build a boundary scanner that splits on `/^#{1,6}\s/m`. The heading line begins the new chunk (not the prior one).
+- [ ] Write an inline assert: a string with two H2 headings produces exactly 2 chunks with `chunkIdx` 0 and 1.
+- [ ] Run `node scripts/pipeline-chunker.js` — expect zero assertion errors.
+
+### Task 1.3: Implement boundary rules 2–4 — code-fence, paragraph, sentence
+
+- [ ] Rule 2: `/^```/m` — split at the closing fence; fence line ends the current chunk.
+- [ ] Rule 3: `\n\n` — split at blank-line paragraph break.
+- [ ] Rule 4: period/`?`/`!` followed by space and uppercase — split after the punctuation.
+- [ ] Inline assert: a string containing a fenced code block is never bisected mid-fence.
+- [ ] Run `node scripts/pipeline-chunker.js` — zero assertion errors.
+
+### Task 1.4: Implement rule 5 — hard-split with overlap re-seed
+
+- [ ] Rule 5 fires when no boundary found within `ceilingChars`. Hard-split at the ceiling.
+- [ ] When rule 5 fires, carry the last `Math.floor(ceilingChars * 0.14)` chars of the prior chunk as overlap seed for the next chunk (50-token overlap at 4 chars/token ≈ 200 chars; proportional to ceiling for JSONL ceiling of 560 → ~78 chars). This satisfies the verdict "Plan Must" §10 re-seed requirement.
+- [ ] Inline assert: a 3000-char string of non-whitespace (no valid boundary) produces chunks all ≤ `ceilingChars` chars and overlap is present.
+- [ ] Run `node scripts/pipeline-chunker.js` — zero assertion errors.
+
+### Task 1.5: Implement tool_result primary rule
+
+- [ ] Add an optional second param `contentType` (`'prose'` | `'tool_result'`). When `'tool_result'`, apply rule 2 (code-fence) as the primary split before falling through to rule 4. Rule 4 (sentence) must not fire on code inside tool_result blocks. (Verdict "Plan Must" §6.)
+- [ ] Inline assert: a tool_result string containing a fenced block and prose sentences splits on the fence, not mid-sentence.
+- [ ] Run `node scripts/pipeline-chunker.js` — zero assertion errors.
+
+### Task 1.6: Commit Phase 1
+
+- [ ] `git add scripts/pipeline-chunker.js`
+- [ ] `git commit -m "feat(chunker): add chunkText() with boundary rules and per-source ceiling param"`
+
+---
+
+## Phase 2: Schema Migration
+
+**Files:** Modify `scripts/setup-knowledge-db.sql`
+**Model:** code_draft | **TDD:** optional
+
+### Task 2.1: Add `chunk_idx` to `policy_sections` and fix unique constraint
+
+- [ ] Append to `scripts/setup-knowledge-db.sql`:
+  ```sql
+  -- Phase 2: chunker/loader migration (issue #142)
+  ALTER TABLE policy_sections
+    ADD COLUMN IF NOT EXISTS chunk_idx INTEGER NOT NULL DEFAULT 0;
+
+  ALTER TABLE policy_sections
+    DROP CONSTRAINT IF EXISTS policy_sections_doc_section_uniq;
+
+  ALTER TABLE policy_sections
+    ADD CONSTRAINT IF NOT EXISTS policy_sections_doc_section_chunk_uniq
+    UNIQUE (doc_id, section_num, chunk_idx);
+  ```
+- [ ] Run migration: `psql $DATABASE_URL -f scripts/setup-knowledge-db.sql`
+- [ ] Verify: `psql $DATABASE_URL -c "\d policy_sections"` — confirm `chunk_idx` column present.
+
+### Task 2.2: Create `memory_entry_chunks` table with GIN + HNSW indexes
+
+- [ ] Append to `scripts/setup-knowledge-db.sql`:
+  ```sql
+  CREATE TABLE IF NOT EXISTS memory_entry_chunks (
+    id         SERIAL PRIMARY KEY,
+    entry_id   INTEGER NOT NULL REFERENCES memory_entries(id) ON DELETE CASCADE,
+    chunk_idx  INTEGER NOT NULL,
+    content    TEXT NOT NULL,
+    content_hash TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (entry_id, chunk_idx)
+  );
+  ALTER TABLE memory_entry_chunks
+    ADD COLUMN IF NOT EXISTS embedding vector(1024);
+  ALTER TABLE memory_entry_chunks
+    ADD COLUMN IF NOT EXISTS fts_vec TSVECTOR
+      GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED;
+  CREATE INDEX IF NOT EXISTS mem_chunks_fts_idx
+    ON memory_entry_chunks USING gin(fts_vec);
+  CREATE INDEX IF NOT EXISTS mem_chunks_hnsw_idx
+    ON memory_entry_chunks USING hnsw (embedding vector_cosine_ops);
+  ```
+- [ ] **Checkpoint CP1 (HNSW):** Verify index created: `psql $DATABASE_URL -c "\d memory_entry_chunks"` — confirm `mem_chunks_hnsw_idx` listed.
+
+### Task 2.3: Add `content_hash` to `session_chunks` and HNSW index
+
+- [ ] Append to `scripts/setup-knowledge-db.sql`:
+  ```sql
+  ALTER TABLE session_chunks
+    ADD COLUMN IF NOT EXISTS content_hash TEXT;
+  CREATE INDEX IF NOT EXISTS session_chunks_hnsw_idx
+    ON session_chunks USING hnsw (embedding vector_cosine_ops);
+  ```
+- [ ] Run migration and verify: `psql $DATABASE_URL -c "\d session_chunks"` — confirm `content_hash` and `session_chunks_hnsw_idx`.
+
+### Task 2.4: Add `content_hash` to `policy_sections`
+
+- [ ] Append to `scripts/setup-knowledge-db.sql`:
+  ```sql
+  ALTER TABLE policy_sections
+    ADD COLUMN IF NOT EXISTS content_hash TEXT;
+  ```
+- [ ] Run migration and verify: `psql $DATABASE_URL -c "\d policy_sections"` — confirm `content_hash` column.
+
+### Task 2.5: Create `v_memory_hits` view (DECISION-001, CP4)
+
+- [ ] Append to `scripts/setup-knowledge-db.sql`:
+  ```sql
+  CREATE OR REPLACE VIEW v_memory_hits AS
+  -- parent_id is display-only: row ID for memory_entry_chunks/policy_sections,
+  -- session ordinal (sessions.num) for session_chunks. Use source_row_id for
+  -- reliable cross-source linkage.
+    SELECT 'memory_entry_chunks'        AS source_table,
+           mc.id                        AS chunk_id,
+           mc.entry_id                  AS parent_id,
+           mc.id                        AS source_row_id,
+           NULL::INTEGER                AS source_ordinal,
+           mc.chunk_idx,
+           (SELECT COUNT(*) FROM memory_entry_chunks x WHERE x.entry_id = mc.entry_id)
+                                        AS total_chunks,
+           me.name                      AS label,
+           substring(mc.content, 1, 300) AS snippet,
+           mc.embedding,
+           mc.fts_vec
+    FROM memory_entry_chunks mc
+    JOIN memory_entries me ON me.id = mc.entry_id
+  UNION ALL
+    SELECT 'policy_sections',
+           ps.id,
+           ps.id,
+           ps.id,
+           NULL::INTEGER,
+           ps.chunk_idx,
+           (SELECT COUNT(*) FROM policy_sections x
+            WHERE x.doc_id = ps.doc_id AND x.section_num = ps.section_num),
+           ps.doc_id || ' §' || coalesce(ps.section_num::TEXT, ''),
+           substring(ps.content, 1, 300),
+           ps.embedding,
+           ps.fts_vec
+    FROM policy_sections ps
+  UNION ALL
+    SELECT 'session_chunks',
+           sc.id,
+           sc.session_num,
+           sc.id,
+           sc.session_num,
+           sc.chunk_idx,
+           (SELECT COUNT(*) FROM session_chunks x
+            WHERE x.session_id = sc.session_id),
+           sc.session_id || ' [' || sc.chunk_kind || ']',
+           substring(sc.content, 1, 300),
+           sc.embedding,
+           sc.fts_vec
+    FROM session_chunks sc;
+  ```
+- [ ] Run migration and verify: `psql $DATABASE_URL -c "\d v_memory_hits"` — confirm all columns including `source_row_id`, `source_ordinal`, `chunk_idx`, `total_chunks`.
+
+### Task 2.6: Commit Phase 2
+
+- [ ] `git add scripts/setup-knowledge-db.sql`
+- [ ] `git commit -m "feat(schema): add chunk_idx, content_hash, HNSW indexes, memory_entry_chunks, v_memory_hits"`
+
+---
+
+## Phase 3: Encoded-CWD Utility
+
+**Files:** Create `scripts/lib/encoded-cwd.js`
+**Model:** code_draft | **TDD:** required
+
+### Task 3.1: Implement `getClaudeProjectDir()`
+
+- [ ] Create `scripts/lib/encoded-cwd.js`:
+  ```js
+  'use strict';
+  const os = require('os');
+  const path = require('path');
+
+  function encodeCwd(cwd) {
+    if (process.platform === 'win32') {
+      // Windows: drive colon becomes dash, backslashes become dashes
+      // e.g. C:\Users\foo\dev\proj → C--Users-foo-dev-proj
+      return cwd.replace(/:/g, '').replace(/\\/g, '-').replace(/^-/, '');
+    }
+    // POSIX: forward slashes become dashes, leading dash stripped
+    return cwd.replace(/\//g, '-').replace(/^-/, '');
+  }
+
+  function getClaudeProjectDir(cwd) {
+    const root = cwd || process.cwd();
+    return path.join(os.homedir(), '.claude', 'projects', encodeCwd(root));
+  }
+
+  module.exports = { getClaudeProjectDir, encodeCwd };
+  ```
+- [ ] **Checkpoint CP3 (Windows path):** Add inline round-trip asserts at bottom of file:
+  ```js
+  if (require.main === module) {
+    const assert = require('assert');
+    // POSIX round-trip
+    const posix = encodeCwd('/home/user/dev/pipeline');
+    assert.strictEqual(posix, 'home-user-dev-pipeline', 'POSIX encode');
+    // Windows round-trip
+    const saved = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    const win = encodeCwd('C:\\Users\\djwmo\\dev\\pipeline');
+    Object.defineProperty(process, 'platform', { value: saved, configurable: true });
+    assert.strictEqual(win, 'C-Users-djwmo-dev-pipeline', 'Windows encode');
+    console.log('encoded-cwd: all assertions passed');
+  }
+  ```
+- [ ] Run: `node scripts/lib/encoded-cwd.js` — expect "all assertions passed".
+
+### Task 3.2: Commit Phase 3
+
+- [ ] `git add scripts/lib/encoded-cwd.js`
+- [ ] `git commit -m "feat(lib): add encoded-cwd utility with Windows-aware path computation"`
+
+---
+
+## Phase 4: Ollama Response Validation
+
+**Files:** Modify `scripts/lib/shared.js`
+**Model:** code_draft | **TDD:** required
+
+### Task 4.1: Harden `ollamaEmbed()` against empty-array responses
+
+- [ ] Locate `ollamaEmbed()` in `scripts/lib/shared.js`. After the existing HTTP-status check and `parsed.embeddings` resolve, add:
+  ```js
+  const embedding = parsed.embeddings[0];
+  if (!Array.isArray(embedding) || embedding.length === 0) {
+    throw new Error(`ollamaEmbed: empty embedding array returned for input (length ${text.length})`);
+  }
+  const magnitude = Math.sqrt(embedding.reduce((s, v) => s + v * v, 0));
+  if (magnitude === 0) {
+    throw new Error(`ollamaEmbed: zero-vector returned for input (length ${text.length})`);
+  }
+  ```
+- [ ] **Checkpoint CP2 (Ollama validation):** Write a minimal test: mock `ollamaEmbed` with `embeddings: [[]]` and confirm it throws rather than returning. Use Node `assert` directly.
+- [ ] Run the mock test — confirm throw.
+
+### Task 4.2: Commit Phase 4
+
+- [ ] `git add scripts/lib/shared.js`
+- [ ] `git commit -m "fix(shared): validate ollamaEmbed response array is non-empty and non-zero-vector"`
+
+---
+
+## Phase 5: Loader
+
+**Files:** Create `scripts/pipeline-memory-loader.js`
+**Model:** code_draft | **TDD:** optional
+
+### Task 5.1: Scaffold CLI entrypoint with subcommand dispatch
+
+- [ ] Create `scripts/pipeline-memory-loader.js` with:
+  - Header comment: usage, description, subcommands (`memory`, `sessions`, `policy`, `--all`), `--force` flag.
+  - `require` for `scripts/lib/shared.js` (`ollamaEmbed`, `connect`, `loadConfig`), `scripts/lib/encoded-cwd.js`, `scripts/pipeline-chunker.js`, `crypto`, `fs`, `path`, `os`.
+  - `const BATCH = 8;`
+  - `const CONST_PROSE_CEILING = 1400;` and `const CONST_JSONL_CEILING = 560;` (DECISION-004).
+  - Argument parsing: `const [,, subcmd, ...flags] = process.argv;` — resolve `--all`, `--force`.
+  - Main dispatch: call `loadMemory()`, `loadSessions()`, or `loadPolicy()` per subcmd.
+- [ ] Verify: `node scripts/pipeline-memory-loader.js` with no args prints usage and exits 0.
+
+### Task 5.2: Implement shared embed-and-upsert helper
+
+- [ ] Write `async function embedAndUpsert(db, chunks, upsertFn, forceFull)`:
+  - Accepts an array of `{ content, chunkIdx, ...sourceFields }` objects.
+  - Computes SHA256 content_hash per chunk: `crypto.createHash('sha256').update(content).digest('hex')`.
+  - Fetches stored hash via `upsertFn` lookup; skips Ollama call if hash matches and `!forceFull` (DECISION-002).
+  - Processes chunks in `BATCH=8` windows.
+  - On Ollama error per chunk: logs `[SKIP] table=<t> id=<id> chunk_idx=<n> err=<msg>` and continues. Never throws.
+  - Prints summary at end: `N embedded, M skipped (hash match), P skipped (error)`.
+
+### Task 5.3: Implement `loadMemory()` — memory_entries source
+
+- [ ] Read `*.md` files from `getClaudeProjectDir()` + `/memory/`. For each file:
+  - `name` = filename without `.md`.
+  - `description` = first line if it starts with `#`, stripped of `#` and whitespace.
+  - `body` = full file content.
+  - Upsert parent row to `memory_entries` with `ON CONFLICT (name) DO UPDATE SET body = EXCLUDED.body`.
+  - Call `chunkText(body, CONST_PROSE_CEILING)` → chunks.
+  - For each chunk: context prefix = `"Memory: {name}\n\n{chunk.content}"`.
+  - Upsert to `memory_entry_chunks` with `ON CONFLICT (entry_id, chunk_idx) DO UPDATE SET content = EXCLUDED.content, content_hash = EXCLUDED.content_hash, embedding = NULL`.
+  - Call `embedAndUpsert()` on that file's chunks.
+
+### Task 5.4: Implement `loadSessions()` — JSONL source
+
+- [ ] Enumerate `*.jsonl` files from `getClaudeProjectDir()`. For each file:
+  - Read line-by-line. Parse each line as JSON.
+  - Skip lines where `role` is not in `['user', 'assistant', 'tool_use', 'tool_result']`.
+  - For `tool_result` content: call `chunkText(content, CONST_JSONL_CEILING, 'tool_result')`.
+  - For all other roles: call `chunkText(content, CONST_JSONL_CEILING)`.
+  - Upsert to `session_chunks` with `ON CONFLICT (session_id, chunk_idx) DO UPDATE SET content = EXCLUDED.content, content_hash = EXCLUDED.content_hash, embedding = NULL`.
+  - **Checkpoint CP4 (per-source calibration):** Confirm 560-char ceiling is passed for all JSONL sources.
+- [ ] Call `embedAndUpsert()` per session file.
+
+### Task 5.5: Implement `loadPolicy()` — CLAUDE.md source
+
+- [ ] Resolve project CLAUDE.md: `path.join(process.env.PROJECT_ROOT || process.cwd(), 'CLAUDE.md')`. `doc_id = 'CLAUDE.md'`.
+- [ ] Resolve global CLAUDE.md: `path.join(os.homedir(), '.claude', 'CLAUDE.md')`. `doc_id = 'global-CLAUDE.md'`.
+- [ ] For each file: split on heading boundaries (`/^#{1,6}\s/m`) to produce one section per heading. `section_num` = integer index (1-based).
+- [ ] For each section: call `chunkText(sectionContent, CONST_PROSE_CEILING)` → sub-chunks.
+- [ ] Upsert to `policy_sections` with `ON CONFLICT (doc_id, section_num, chunk_idx) DO UPDATE SET content = EXCLUDED.content, content_hash = EXCLUDED.content_hash, embedding = NULL`.
+- [ ] Call `embedAndUpsert()` per document.
+
+### Task 5.6: Commit Phase 5
+
+- [ ] `git add scripts/pipeline-memory-loader.js`
+- [ ] `git commit -m "feat(loader): add pipeline-memory-loader with memory/sessions/policy subcommands"`
+
+---
+
+## Phase 6: `cmdHybrid` Update
+
+**Files:** Modify `scripts/pipeline-embed.js` (around line 339)
+**Model:** code_draft | **TDD:** optional
+
+### Task 6.1: Add `v_memory_hits` query to `cmdHybrid`
+
+- [ ] In `cmdHybrid`, add a query against `v_memory_hits` for both semantic (cosine via embedding) and FTS (via `fts_vec`). Do not remove existing per-table queries if they serve non-chunk tables.
+- [ ] Format result rows to display: `[source_table] label — snippet... (chunk N of M)`.
+- [ ] Ensure existing TABLES queries continue to function; do not break non-chunk table output.
+- [ ] Manual verification: `node scripts/pipeline-embed.js hybrid "destructive operation"` — confirm at least one result from `v_memory_hits` with chunk position indicator.
+
+### Task 6.2: Create `v_memory_hits` in embed setup path
+
+- [ ] In `pipeline-embed.js` setup/introspection path (where other schema objects are created), add the `CREATE OR REPLACE VIEW v_memory_hits AS ...` DDL. This ensures the view exists even if `setup-knowledge-db.sql` was not re-run, and satisfies the verdict constraint that the view must exist before any agent queries it.
+
+### Task 6.3: Commit Phase 6
+
+- [ ] `git add scripts/pipeline-embed.js`
+- [ ] `git commit -m "feat(embed): query v_memory_hits in cmdHybrid with chunk position indicator"`
+
+---
+
+## Phase 7: Documentation
+
+**Files:** Modify `docs/memory.md`, `CHANGELOG.md`
+**Model:** short_draft | **TDD:** optional
+
+### Task 7.1: Update `docs/memory.md` loader status (line 248 paragraph)
+
+- [ ] Replace the paragraph at line 248 that begins "Pipeline does not ship a loader for these six tables" with:
+  > Pipeline ships loaders for `memory_entries`, `policy_sections`, and `session_chunks` via `node scripts/pipeline-memory-loader.js`. Subcommands: `memory`, `sessions`, `policy`, `--all`. Use `--force` for a full rebuild. Loaders for `incidents`, `checklist_items`, and `corpus_files` are deferred.
+- [ ] Verify line count in updated file is within expected range.
+
+### Task 7.2: Update `docs/memory.md` Populator column (lines 60–66)
+
+- [ ] In the table near lines 60–66, update the "Populator" column for `memory_entries`, `session_chunks`, and `policy_sections` from whatever current value to `pipeline-memory-loader.js`.
+
+### Task 7.3: Add CHANGELOG entry
+
+- [ ] In `CHANGELOG.md` under `[Unreleased]` > `Added`:
+  ```
+  - `scripts/pipeline-chunker.js`: boundary-aware text chunker with per-source token ceiling (1400 chars prose / 560 chars JSONL)
+  - `scripts/pipeline-memory-loader.js`: loaders for memory_entries, policy_sections, session_chunks with idempotent SHA256 content_hash skip and BATCH=8 error isolation
+  - `scripts/lib/encoded-cwd.js`: Windows-aware Claude project directory path utility
+  - `v_memory_hits` SQL view: unified chunk retrieval surface with chunk position metadata
+  - HNSW vector indexes on memory_entry_chunks.embedding and session_chunks.embedding
+  ```
+
+### Task 7.4: Commit Phase 7
+
+- [ ] `git add docs/memory.md CHANGELOG.md`
+- [ ] `git commit -m "docs: update memory.md loader status and add CHANGELOG entries for chunker/loader"`
+
+---
+
+## Phase 8: Test Gate (`scripts/test-chunker.js`)
+
+**Files:** Create `scripts/test-chunker.js`
+**Model:** code_draft | **TDD:** required
+
+This is DECISION-003: automated test runner for all five §6 acceptance tests. Exit 0 = pass, exit 1 = fail.
+
+### Task 8.1: Scaffold test runner with helpers
+
+- [ ] Create `scripts/test-chunker.js` with:
+  - `const assert = require('assert');`
+  - `let passed = 0; let failed = 0;`
+  - Helper `run(name, fn)` that calls `fn()` in try/catch, logs pass/fail, increments counters.
+  - At end: `console.log(\`${passed} passed, ${failed} failed\`); process.exit(failed > 0 ? 1 : 0);`
+
+### Task 8.2: Test 1 — Pathological policy section (>8000 chars)
+
+- [ ] Construct a string of 8100 chars (mix of words and `##` headings every 2000 chars).
+- [ ] Call `chunkText(str, 1400)`. Assert: `chunks.length >= 2`; no chunk's `content.length > 1600`; chunks cover the full source text without omission.
+- [ ] Verify a mid-section phrase is retrievable by checking that phrase appears in one of the returned chunk `content` strings.
+
+### Task 8.3: Test 2 — Pathological memory body (>20000 chars)
+
+- [ ] Construct a 20500-char string with content spread across 10 sections.
+- [ ] Call `chunkText(str, 1400)`. Assert: `chunks.length >= 5`; no Ollama overrun (chunk length ≤ 1600 chars); a phrase present only in the 4th or later chunk is found in chunk index ≥ 3.
+
+### Task 8.4: Test 3 — Pathological session message (>4000 chars)
+
+- [ ] Construct a 4200-char string with JSON-escaped content and a fenced code block (representing a tool_result).
+- [ ] Call `chunkText(str, 560, 'tool_result')`. Assert: `chunks.length >= 2`; fenced block is not bisected mid-fence; all chunk lengths ≤ 672 chars (20% headroom over 560 ceiling).
+
+### Task 8.5: Test 4 — Idempotence (content_hash logic)
+
+- [ ] Simulate two loader runs against identical source text. On first run: hash stored = null, embed call made. On second run: stored hash matches computed hash → embed call skipped.
+- [ ] Assert: row count identical after both simulated runs; Ollama call mock invoked exactly once total.
+
+### Task 8.6: Test 5 — Ollama empty-array validation + partial failure resilience
+
+- [ ] **Checkpoint CP2 (Ollama validation):** Mock `ollamaEmbed` to return `{ embeddings: [[]] }` for one chunk and valid embeddings for others.
+- [ ] Assert: the empty-array chunk throws (caught per-chunk), is logged, and skipped. Neighboring chunks in the same BATCH=8 window embed successfully. The loader does not abort.
+
+### Task 8.7: Test — Windows encoded-cwd path round-trip
+
+- [ ] **Checkpoint CP3 (Windows path):** Import `encodeCwd` from `scripts/lib/encoded-cwd.js`.
+- [ ] Assert POSIX: `encodeCwd('/home/user/dev/pipeline') === 'home-user-dev-pipeline'`.
+- [ ] Assert Windows simulation: override `process.platform` temporarily; `encodeCwd('C:\\Users\\djwmo\\dev\\pipeline') === 'C-Users-djwmo-dev-pipeline'`.
+
+### Task 8.8: Run test suite and confirm green
+
+- [ ] `node scripts/test-chunker.js`
+- [ ] Expected: all tests pass, exit 0. Fix any failures before proceeding to Phase 9.
+
+### Task 8.9: Commit Phase 8
+
+- [ ] `git add scripts/test-chunker.js`
+- [ ] `git commit -m "test: add test-chunker.js covering all five §6 acceptance gate tests"`
+
+---
+
+## Phase 9: Verification Against Real Project Data
+
+**Model:** no_llm (script execution only)
+
+### Task 9.1: Run memory loader against this project's memory files
+
+- [ ] `PROJECT_ROOT=$(pwd) node scripts/pipeline-memory-loader.js memory`
+- [ ] Confirm output: `N embedded, M skipped (hash match), P skipped (error)`. Expect P = 0 on first run.
+- [ ] `psql $DATABASE_URL -c "SELECT COUNT(*) FROM memory_entry_chunks;"` — confirm row count > 0.
+
+### Task 9.2: Run policy loader against project and global CLAUDE.md
+
+- [ ] `PROJECT_ROOT=$(pwd) node scripts/pipeline-memory-loader.js policy`
+- [ ] Confirm no Ollama overrun errors (the "Destructive Operation Guards" section in CLAUDE.md exceeds 3000 chars and must be sub-chunked cleanly).
+- [ ] `psql $DATABASE_URL -c "SELECT doc_id, COUNT(*) FROM policy_sections GROUP BY doc_id;"` — confirm both `CLAUDE.md` and `global-CLAUDE.md` present with multiple rows.
+
+### Task 9.3: Run session loader against existing JSONLs
+
+- [ ] `PROJECT_ROOT=$(pwd) node scripts/pipeline-memory-loader.js sessions`
+- [ ] Confirm JSONL files are found (non-zero count). If count = 0, verify `getClaudeProjectDir()` resolves correctly on this platform.
+- [ ] `psql $DATABASE_URL -c "SELECT COUNT(*) FROM session_chunks WHERE embedding IS NOT NULL;"` — confirm > 0.
+
+### Task 9.4: Verify embedding stats
+
+- [ ] `node scripts/pipeline-embed.js stats` — confirm 100% coverage on `memory_entry_chunks`, `policy_sections`, `session_chunks` (0 rows with null embedding after loader run).
+
+### Task 9.5: Verify hybrid search returns chunk results
+
+- [ ] `node scripts/pipeline-embed.js hybrid "destructive operation"` — expect at least one result from `v_memory_hits` with a `(chunk N of M)` position indicator.
+- [ ] `node scripts/pipeline-embed.js hybrid "encoded cwd"` — expect result from session or memory chunks.
+
+### Task 9.6: Final commit
+
+- [ ] `git add -A`
+- [ ] `git commit -m "chore: verify loader integration against real project data"`
+
+---
+
+## Build Sequence
+
+1. **Phase 1** — `pipeline-chunker.js` (no dependencies; pure function)
+2. **Phase 2** — Schema migration (depends on Phase 1 design being stable)
+3. **Phase 3** — `encoded-cwd.js` (no dependencies; pure utility)
+4. **Phase 4** — `ollamaEmbed` hardening (depends on understanding of expected interface; no code dependencies)
+5. **Phase 5** — `pipeline-memory-loader.js` (depends on Phases 1, 2, 3, 4)
+6. **Phase 6** — `cmdHybrid` update (depends on Phase 2 view DDL)
+7. **Phase 7** — Documentation (depends on Phases 1–5 being implementation-stable)
+8. **Phase 8** — `test-chunker.js` (depends on Phases 1, 3, 4; runs against real DB for Tests 4–5)
+9. **Phase 9** — Verification (depends on all prior phases; required before PR open)
+
+---
+
+## Checkpoint Registry
+
+| ID | Phase | Verdict reference | What to verify |
+|----|-------|-------------------|----------------|
+| CP1 | 2.2 | HNSW index — Invalidated Assumption §2 | `\d memory_entry_chunks` shows `mem_chunks_hnsw_idx` |
+| CP2 | 4.1, 8.6 | Ollama empty-array — Invalidated Assumption §4 | `ollamaEmbed` throws on `embeddings: [[]]`; Test 5 passes |
+| CP3 | 3.1, 8.7 | Windows encoded-cwd — Invalidated Assumption §5 | Round-trip asserts pass on Windows path format |
+| CP4 | 5.4 | Per-source calibration — Invalidated Assumption §1 | JSONL loader passes 560-char ceiling; prose loader passes 1400-char ceiling |
+
+All four checkpoints must be verified before any merge request is opened.
+
+---
+
+## Pre-Merge Gate
+
+- [ ] `node scripts/test-chunker.js` exits 0 — paste full output in PR description (DECISION-003).
+- [ ] Phase 9 verification complete — `pipeline-embed.js stats` shows 0 null-embedding rows on all three chunk tables.
+- [ ] All four checkpoints CP1–CP4 verified.
+- [ ] No chunk written with a zero-vector embedding (validate via `psql -c "SELECT COUNT(*) FROM memory_entry_chunks WHERE embedding IS NULL"` after loader run with no errors).

--- a/docs/specs/2026-04-26-chunking-loader-spec.md
+++ b/docs/specs/2026-04-26-chunking-loader-spec.md
@@ -1,0 +1,351 @@
+---
+title: Chunker / loader for high-fidelity semantic memory retrieval
+date: 2026-04-26
+status: draft
+change_size: LARGE
+related: [postgres-task-60, github-issue-tbd, deferred-from-issue-109]
+---
+
+# Spec: Chunker / Loader for High-Fidelity Semantic Memory Retrieval
+
+## 1. Problem
+
+On 2026-04-26 a peer Claude session attempted to populate three previously-empty memory
+tables: `session_chunks` (327 rows), `memory_entries` (43 rows), and `policy_sections`
+(853 rows). All three batches failed with Ollama's "input length exceeds context length"
+error and landed at 0 rows embedded. Four other tables — sessions, gotchas,
+checklist_items, corpus_files — embedded cleanly because their content is short by
+construction. The failure is not random; it is structurally guaranteed for any table whose
+`textFn` produces output that exceeds mxbai-embed-large's 512-token hard cap.
+
+The root cause is threefold. First, mxbai-embed-large enforces a 512-token context limit
+that cannot be lifted by passing `num_ctx` to Ollama — the model's native cap is fixed.
+Second, `policy_sections.textFn` applies no truncation at all (line 124 of
+`scripts/pipeline-embed.js`), so a section like the Destructive Operation Guards block in
+CLAUDE.md — which runs to several thousand chars — reaches the embedder intact.
+`memory_entries.body` truncates to 5000 chars (line 114), which is approximately 1250
+tokens at 4 chars/token — still 2.4× over the cap. Third, `cmdIndex` batches in groups
+of 32 and fails the entire batch on a single Ollama error, so one oversized row silently
+discards up to 31 others with no per-row retry.
+
+The practical consequence is that the six memory tables listed at `docs/memory.md:248`
+("Pipeline does not ship a loader for these six tables") remain permanently empty in every
+real project. Semantic memory — the feature that lets agents retrieve relevant context from
+past sessions, policy, and auto-memory files — is a dead letter. This spec closes that gap
+for the three highest-value tables: `memory_entries`, `policy_sections`, and
+`session_chunks`.
+
+## 2. Goals
+
+- Ship `scripts/pipeline-chunker.js`: a standalone, pure-function text chunker with
+  configurable token budget and boundary-aware splitting.
+- Ship `scripts/pipeline-memory-loader.js`: loaders for `memory_entries`,
+  `policy_sections`, and `session_chunks` that source rows from the filesystem and
+  embed via the chunker.
+- Eliminate Ollama "input length exceeds context length" errors for all three tables by
+  guaranteeing no chunk exceeds 400 tokens (= 1600 chars at 4 chars/token).
+- Achieve 100% embedding coverage on pathological inputs: policy sections > 8000 chars,
+  memory bodies > 20000 chars, session messages > 4000 chars.
+- Ensure idempotent loader runs: re-running the loader never duplicates rows.
+- Limit blast radius per Ollama error to 8 rows by batching at BATCH=8 in the loader
+  (down from cmdIndex's BATCH=32).
+- Require no schema migration to existing tables except adding `chunk_idx` to
+  `policy_sections` (default 0) and creating the `memory_entry_chunks` sibling table.
+
+## 3. Non-goals
+
+- Swapping mxbai-embed-large for a longer-context model (bge-m3 at 1024 dims or
+  nomic-embed-text-v1.5 at 768 dims) — this is Strategy B and a separate spec.
+- Loaders for `incidents`, `checklist_items`, or `corpus_files` — low value in this
+  project; no natural filesystem source-of-truth exists for these tables.
+- PDF or binary content extraction for `corpus_files`.
+- Changing the `embedding_model` config key or Ollama model selection logic.
+- Search ranking tuning (RRF weights, score thresholds, reranking).
+- Multi-project or cross-project memory federation.
+
+## 4. Recommended Approach: Strategy A — Chunker with mxbai-embed-large
+
+**Recommendation: implement Strategy A.** Build the chunker; keep mxbai-embed-large as the
+embedder. Do not swap the model in this PR.
+
+Strategy B (switch embedder to bge-m3 or nomic-embed-text-v1.5) is insufficient on its
+own. bge-m3 has an 8192-token native context, which covers most policy sections and memory
+bodies. But a single multi-message assistant turn in a Claude Code session JSONL can exceed
+10,000 tokens — a `tool_result` block containing a large file read, followed by a long
+reasoning response, easily hits this ceiling. Strategy B defers the overrun problem rather
+than solving it. Chunking is mandatory for `session_chunks` regardless, because that table
+is literally designed as a chunk table.
+
+Strategy C (bge-m3 for short tables + chunker for unbounded tables) gives the best
+embedding fidelity — fewer chunks, richer context per vector — but doubles this PR's
+surface area. It requires a schema migration to align vector dimensions (bge-m3 = 1024, but
+nomic-embed-text-v1.5 = 768 requires column type changes), a re-embed pass over all
+existing rows, and validation that the new model's similarity space is coherent with existing
+cosine-distance thresholds. That is a separate, careful migration, not a tack-on.
+
+The chunker is the load-bearing piece. Once it ships and proves out on real projects, the
+bge-m3 follow-up becomes a bounded, low-risk upgrade: swap the model, re-run the loader,
+validate search quality. The inverse order — swap the model first, add the chunker later —
+leaves `session_chunks` broken throughout.
+
+## 5. Design
+
+### 5.1 Chunker (`scripts/pipeline-chunker.js`)
+
+**Token-counting strategy:** char-based heuristic at 1 token ≈ 4 chars. Conservative for
+English prose and mixed code. A 1400-char window yields ≤ 350 tokens, providing a 30%
+safety margin below the 512-token hard cap even if the heuristic is off by 15% for
+dense code or CJK content.
+
+**Chunk parameters:**
+- Target size: 350 tokens (1400 chars)
+- Hard max: 400 tokens (1600 chars)
+- Overlap: 50 tokens (200 chars) carried from the tail of the prior chunk into the head of
+  the next, preserving sentence continuity at boundaries
+
+**Boundary rules (evaluated in priority order):**
+
+1. Markdown heading lines matching `/^#{1,6}\s/m` — always split before a heading; the
+   heading line begins the new chunk.
+2. Code-fence boundaries matching `/^```/m` — split at the closing fence; the fence line
+   ends the current chunk.
+3. Blank-line paragraph breaks (`\n\n`) — split at the blank line.
+4. Sentence breaks: period or question mark or exclamation followed by a space and an
+   uppercase letter — split after the punctuation.
+5. Fixed-char window at 1400 chars with no boundary found — hard split; no overlap
+   adjustment at this fallback.
+
+**Exported interface:**
+
+```js
+// scripts/pipeline-chunker.js
+function chunkText(text, opts = {}) {
+  // opts: { targetChars, maxChars, overlapChars }
+  // returns Array<{ content: string, chunkIdx: number }>
+}
+module.exports = { chunkText };
+```
+
+Context prefix is injected by the loader (not the chunker) so the chunker stays
+table-agnostic.
+
+### 5.2 Loader (`scripts/pipeline-memory-loader.js`)
+
+**Sources by table:**
+
+- `memory_entries` — reads `~/.claude/projects/<encoded-cwd>/memory/*.md`. Each file maps
+  to one parent row: `name` = filename without `.md` extension, `description` = first line
+  if it starts with `#`, `body` = full file content. Chunks written to
+  `memory_entry_chunks`.
+- `session_chunks` — reads `~/.claude/projects/<encoded-cwd>/*.jsonl`. Each JSONL line is
+  one message. Messages with role `user`, `assistant`, `tool_use`, or `tool_result` become
+  chunks. `chunk_kind` = message role. If a single message's content exceeds 1600 chars,
+  `chunkText()` sub-chunks it; sub-chunks share `session_id` and increment `chunk_idx`.
+- `policy_sections` — reads project `CLAUDE.md` (at `$PROJECT_ROOT/CLAUDE.md`) and global
+  `~/.claude/CLAUDE.md`. Splits on heading boundaries to produce one row per section.
+  `doc_id` = filename (`CLAUDE.md` or `global-CLAUDE.md`). If a section's content exceeds
+  1600 chars, sub-chunks it; sub-chunks share `doc_id + section_num` and increment
+  `chunk_idx`.
+
+**Idempotence keys:**
+
+| Table | Dedup key |
+|-------|-----------|
+| `memory_entries` | `name` |
+| `memory_entry_chunks` | `(entry_id, chunk_idx)` |
+| `session_chunks` | `(session_id, chunk_idx)` |
+| `policy_sections` | `(doc_id, section_num, chunk_idx)` |
+
+Re-running the loader issues `INSERT ... ON CONFLICT (...) DO UPDATE SET content = EXCLUDED.content, embedding = NULL` so stale embeddings are cleared and re-queued.
+
+**Embedding orchestration:** The loader calls `ollamaEmbed()` from `scripts/lib/shared.js`
+directly. It does not go through `pipeline-embed.js cmdIndex`. The loader owns its embed
+loop with BATCH=8. On an Ollama error for any chunk, the loader logs the error with chunk
+identity (`table, id, chunk_idx`) and continues to the next batch. It does not abort. After
+all chunks are attempted, it prints a summary: `N chunks embedded, M skipped (errors)`.
+
+### 5.3 Schema Additions
+
+**`policy_sections`** already acts as a chunk table (one row per heading). Add one column:
+
+```sql
+ALTER TABLE policy_sections
+  ADD COLUMN IF NOT EXISTS chunk_idx INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE policy_sections
+  DROP CONSTRAINT IF EXISTS policy_sections_doc_section_uniq;
+
+ALTER TABLE policy_sections
+  ADD CONSTRAINT policy_sections_doc_section_chunk_uniq
+  UNIQUE (doc_id, section_num, chunk_idx);
+```
+
+**`memory_entry_chunks`** (new sibling table):
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_entry_chunks (
+  id          SERIAL PRIMARY KEY,
+  entry_id    INTEGER NOT NULL REFERENCES memory_entries(id) ON DELETE CASCADE,
+  chunk_idx   INTEGER NOT NULL,
+  content     TEXT NOT NULL,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (entry_id, chunk_idx)
+);
+ALTER TABLE memory_entry_chunks
+  ADD COLUMN IF NOT EXISTS embedding vector(1024);
+ALTER TABLE memory_entry_chunks
+  ADD COLUMN IF NOT EXISTS fts_vec TSVECTOR
+    GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED;
+CREATE INDEX IF NOT EXISTS mem_chunks_fts_idx
+  ON memory_entry_chunks USING gin(fts_vec);
+```
+
+**`session_chunks`** — no schema change. The table already has `session_id`, `chunk_idx`,
+`chunk_kind`, `content`, `embedding vector(1024)`, `fts_vec`. The loader populates it
+directly.
+
+**Context prefix format injected by loader before embedding:**
+
+- `memory_entry_chunks`: `"Memory: {name}\n\n{chunk_content}"`
+- `policy_sections`: `"Policy: {doc_id} §{section_num} {section_title}\n\n{chunk_content}"`
+- `session_chunks`: `"Session: {session_id} [{chunk_kind}]\n\n{chunk_content}"`
+
+### 5.4 Search-Time Reassembly (`pipeline-embed.js` `cmdHybrid`)
+
+Add a SQL view `v_memory_hits` that unions all three chunk sources into a single shape:
+
+```sql
+CREATE OR REPLACE VIEW v_memory_hits AS
+  SELECT 'memory_entry_chunks' AS source_table,
+         mc.id AS chunk_id, mc.entry_id AS parent_id,
+         me.name AS label,
+         substring(mc.content, 1, 120) AS snippet,
+         mc.embedding, mc.fts_vec
+  FROM memory_entry_chunks mc
+  JOIN memory_entries me ON me.id = mc.entry_id
+UNION ALL
+  SELECT 'policy_sections', ps.id, ps.id,
+         ps.doc_id || ' §' || coalesce(ps.section_num, '') AS label,
+         substring(ps.content, 1, 120),
+         ps.embedding, ps.fts_vec
+  FROM policy_sections ps
+UNION ALL
+  SELECT 'session_chunks', sc.id, sc.session_num,
+         sc.session_id || ' [' || sc.chunk_kind || ']' AS label,
+         substring(sc.content, 1, 120),
+         sc.embedding, sc.fts_vec
+  FROM session_chunks sc;
+```
+
+`cmdHybrid` queries `v_memory_hits` for semantic and FTS search. Callers receive
+`(source_table, chunk_id, parent_id, label, snippet, score)` and never stitch across
+tables manually. The view is created in `pipeline-embed.js` setup path alongside other
+schema introspection.
+
+## 6. Test Plan (CRITICAL)
+
+The following five tests are a hard acceptance gate. **Any failure in items 1–5 is a hard
+blocker for merge.** "Works on my machine" with typical data is not acceptance. The tests
+must be run against the pathological inputs described below.
+
+**Test 1 — Pathological policy section.**
+Construct or identify a `CLAUDE.md` section whose content exceeds 8000 chars (the
+Destructive Operation Guards section in the project CLAUDE.md is a candidate; pad if
+needed). Run the loader. Assert: (a) no Ollama overrun errors logged; (b) `SELECT
+COUNT(*) FROM policy_sections WHERE doc_id = 'CLAUDE.md'` shows ≥ 2 rows for that
+section (chunk_idx 0 and 1 at minimum); (c) `node scripts/pipeline-embed.js hybrid
+"<phrase verbatim from the middle of the section>"` returns a result whose snippet
+contains that phrase.
+
+**Test 2 — Pathological memory body.**
+Create a `.md` file in `~/.claude/projects/<encoded-cwd>/memory/` whose body is > 20000
+chars (approximately 5000 tokens). Run the loader. Assert: (a) `SELECT COUNT(*) FROM
+memory_entry_chunks WHERE entry_id = <id>` ≥ 5; (b) no Ollama overrun errors; (c) hybrid
+search for a phrase that appears only in chunk index 3 or later returns a result from that
+chunk.
+
+**Test 3 — Pathological session transcript.**
+Identify or construct a JSONL where a single assistant message body exceeds 4000 chars.
+Run the loader. Assert: (a) that message produces ≥ 2 rows in `session_chunks` with
+distinct `chunk_idx` values; (b) all embed without error; (c) hybrid search for a phrase
+from the second sub-chunk returns that chunk.
+
+**Test 4 — Idempotence.**
+Run the loader twice against identical sources without modifying any source files between
+runs. Assert: row counts in `memory_entry_chunks`, `session_chunks`, and `policy_sections`
+are identical after both runs. No duplicate rows.
+
+**Test 5 — Partial failure resilience.**
+Inject one chunk whose content is 2000 chars of repeated non-ASCII characters (which
+exceed the 512-token cap even under the conservative heuristic) by directly inserting a
+row with `embedding = NULL` and an oversize `content` value. Run `node
+scripts/pipeline-embed.js index`. Assert: (a) the oversize chunk is logged as an error
+with its table and id; (b) all other chunks in the same BATCH=8 window that are within
+budget embed successfully; (c) the loader does not abort or throw an uncaught exception.
+
+## 7. Implementation Order
+
+Dependencies must be resolved in this sequence:
+
+1. **`scripts/pipeline-chunker.js`** — pure function, no DB or filesystem dependencies.
+   Write and unit-test in isolation before touching any other file.
+
+2. **Migration SQL** (add to `scripts/setup-knowledge-db.sql` and run manually in dev):
+   `ALTER TABLE policy_sections ADD COLUMN IF NOT EXISTS chunk_idx INTEGER NOT NULL DEFAULT 0`,
+   drop/recreate unique constraint, `CREATE TABLE IF NOT EXISTS memory_entry_chunks`.
+
+3. **`scripts/pipeline-memory-loader.js`** — depends on `pipeline-chunker.js` and
+   `scripts/lib/shared.js` (`ollamaEmbed`, `connect`, `loadConfig`). No dependency on
+   `pipeline-embed.js`.
+
+4. **`scripts/pipeline-embed.js`** — add `CREATE OR REPLACE VIEW v_memory_hits` to the
+   setup/introspection path; update `cmdHybrid` to query `v_memory_hits` in addition to
+   (or instead of) individual chunk table queries.
+
+5. **`docs/memory.md`** — update the paragraph at line 248 that states "Pipeline does not
+   ship a loader for these six tables." Replace with: "Pipeline ships loaders for
+   `memory_entries`, `policy_sections`, and `session_chunks`. Loaders for `incidents`,
+   `checklist_items`, and `corpus_files` are deferred."
+
+## 8. Out of Scope (Follow-up Work)
+
+- **Strategy B — longer-context embedder swap.** Switching to bge-m3 (1024 dims, 8192
+  native context) or nomic-embed-text-v1.5 (768 dims, 8192 context) is a clean follow-on
+  after the chunker proves out. bge-m3 is dimension-compatible with existing `vector(1024)`
+  columns; nomic requires a column type migration. Both require a full re-embed pass.
+  Tracked as separate spec.
+- **`corpus_files` PDF/binary content extraction.** Requires a text-extraction pipeline
+  (pdftotext or equivalent) before chunking is possible.
+- **Loaders for `incidents` and `checklist_items`.** No natural filesystem source-of-truth
+  in this project. These tables are populated via pipeline commands, not file mirrors.
+- **Search ranking and RRF weight tuning.** The current hybrid search weights are
+  unchanged by this spec.
+- **Multi-project memory federation.** Each loader run is scoped to the project root of
+  the calling process.
+
+## 9. Risks
+
+**Risk 1 — Char-based heuristic underestimates token count for code and CJK.**
+Dense code blocks and CJK text have higher token density than English prose. A 1400-char
+chunk of Japanese text can be 700+ tokens, well over the 512-token cap.
+Mitigation: the 1400-char target (350 tokens at the heuristic rate) provides a 30% margin
+below the 512-token cap. Code-fence boundary detection (rule 2) splits before and after
+fenced blocks, limiting code density within a chunk. If the margin proves insufficient in
+testing, reduce target to 1200 chars (300 tokens) with no other changes.
+
+**Risk 2 — BATCH=8 loader is 4× slower than cmdIndex BATCH=32.**
+The loader's conservative batch size reduces throughput. For a project with 853 policy
+sections each producing 2 chunks on average (1706 chunks), BATCH=8 means 214 Ollama calls
+vs. 54 at BATCH=32. At ~150 ms per Ollama call, that is ~32 seconds vs. ~8 seconds.
+Mitigation: loaders run infrequently (on-demand, not in the hot path). The throughput
+tradeoff is accepted in exchange for per-chunk error isolation. BATCH can be raised to 16
+in a follow-up once the overrun risk is validated against real data.
+
+**Risk 3 — `memory_entry_chunks` fragments memory retrieval across two tables.**
+Adding a sibling chunk table means queries that previously scanned `memory_entries` miss
+chunk-level content unless they also scan `memory_entry_chunks`. Agents that bypass
+`cmdHybrid` and query directly will see only the parent row.
+Mitigation: `v_memory_hits` view unifies all three chunk sources behind a single query
+surface. `cmdHybrid` is the sole search entry point documented for agent use. Parent rows
+in `memory_entries` remain intact and searchable for short bodies that fit in a single
+chunk (chunk_idx = 0 only).

--- a/scripts/lib/encoded-cwd.js
+++ b/scripts/lib/encoded-cwd.js
@@ -1,0 +1,168 @@
+'use strict';
+
+/**
+ * Shared utility: encode a filesystem path into Claude Code's per-project directory name.
+ *
+ * Claude Code stores per-project transcripts and memory at:
+ *   ~/.claude/projects/<encoded-cwd>/
+ *
+ * Encoding rule: replace every character NOT matching /[A-Za-z0-9-]/ with '-'.
+ * Hyphens stay hyphens. No collapsing of consecutive dashes. No special casing —
+ * the same replace runs on Windows paths (backslashes, colons) and POSIX paths
+ * (leading slash) alike.
+ *
+ * Examples:
+ *   /home/user/dev/myproj          -> -home-user-dev-myproj
+ *   C:\Users\djwmo\dev\pipeline    -> C--Users-djwmo-dev-pipeline
+ *   /home/user/path with spaces/p  -> -home-user-path-with-spaces-p
+ *
+ * Plan: docs/plans/2026-04-26-chunker-loader-plan.md (Phase 3)
+ */
+
+const path = require('path');
+const os = require('os');
+
+/**
+ * Encode an absolute filesystem path into Claude Code's per-project directory name.
+ *
+ * Trailing slashes and backslashes are trimmed before encoding so that
+ * `/foo/bar/` and `/foo/bar` produce identical results.
+ *
+ * @param {string} cwdAbsolute - Absolute working-directory path
+ * @returns {string} Encoded directory name (no leading ~/.claude/projects/ prefix)
+ */
+function encodeCwd(cwdAbsolute) {
+  if (!cwdAbsolute) return '';
+  // Trim trailing path separators (both / and \) before encoding.
+  const trimmed = cwdAbsolute.replace(/[/\\]+$/, '');
+  return trimmed.replace(/[^A-Za-z0-9-]/g, '-');
+}
+
+/**
+ * Resolve the absolute path to ~/.claude/projects/<encoded-cwd>/ for a given cwd.
+ *
+ * Does not check whether the directory exists on disk.
+ *
+ * @param {string} cwdAbsolute - Absolute working-directory path
+ * @returns {string} Absolute directory path
+ */
+function getClaudeProjectDir(cwdAbsolute) {
+  return path.join(os.homedir(), '.claude', 'projects', encodeCwd(cwdAbsolute));
+}
+
+module.exports = { encodeCwd, getClaudeProjectDir };
+
+// ---------------------------------------------------------------------------
+// Inline tests — run with: node scripts/lib/encoded-cwd.js
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const assert = require('assert');
+  const fs = require('fs');
+  let passed = 0;
+
+  function test(label, fn) {
+    try {
+      fn();
+      console.log(`PASS  ${label}`);
+      passed++;
+    } catch (err) {
+      console.error(`FAIL  ${label}`);
+      console.error(`      ${err.message}`);
+      process.exitCode = 1;
+    }
+  }
+
+  // Test 1: POSIX path
+  test('encodeCwd POSIX /home/user/dev/myproj', () => {
+    assert.strictEqual(
+      encodeCwd('/home/user/dev/myproj'),
+      '-home-user-dev-myproj'
+    );
+  });
+
+  // Test 2: Windows path without trailing backslash
+  test('encodeCwd Windows C:\\Users\\djwmo\\dev\\pipeline (no trailing slash)', () => {
+    assert.strictEqual(
+      encodeCwd('C:\\Users\\djwmo\\dev\\pipeline'),
+      'C--Users-djwmo-dev-pipeline'
+    );
+  });
+
+  // Test 3: Windows path WITH trailing backslash — must produce same result as test 2
+  test('encodeCwd Windows C:\\Users\\djwmo\\dev\\pipeline\\ (trailing backslash trimmed)', () => {
+    assert.strictEqual(
+      encodeCwd('C:\\Users\\djwmo\\dev\\pipeline\\'),
+      'C--Users-djwmo-dev-pipeline'
+    );
+  });
+
+  // Test 4: Path with spaces
+  test('encodeCwd path with spaces', () => {
+    assert.strictEqual(
+      encodeCwd('/home/user/path with spaces/proj'),
+      '-home-user-path-with-spaces-proj'
+    );
+  });
+
+  // Test 5: Empty string
+  test('encodeCwd empty string returns empty string', () => {
+    assert.strictEqual(encodeCwd(''), '');
+  });
+
+  // Test 6: Period encoded
+  test('encodeCwd period in path becomes dash', () => {
+    assert.strictEqual(
+      encodeCwd('foo/bar.baz'),
+      'foo-bar-baz'
+    );
+  });
+
+  // Test 7: getClaudeProjectDir ends with correct encoded segment
+  test('getClaudeProjectDir ends with C--Users-djwmo-dev-pipeline', () => {
+    const result = getClaudeProjectDir('C:\\Users\\djwmo\\dev\\pipeline');
+    assert.ok(
+      result.endsWith('C--Users-djwmo-dev-pipeline'),
+      `Expected result to end with 'C--Users-djwmo-dev-pipeline', got: ${result}`
+    );
+  });
+
+  // Test 8: Round-trip against the real on-disk directory for the live cwd.
+  // Wraps in try/catch so the file remains testable in isolation (e.g., in a
+  // fresh checkout where no Claude Code project directory exists yet). But in
+  // the normal pipeline project environment this MUST succeed.
+  test('getClaudeProjectDir round-trip: ~/.claude/projects/<encoded-cwd>/ exists on disk', () => {
+    const cwd = process.cwd();
+    const projectDir = getClaudeProjectDir(cwd);
+    let exists = false;
+    let skipReason = null;
+    try {
+      exists = fs.existsSync(projectDir);
+    } catch (statErr) {
+      skipReason = statErr.message;
+    }
+    if (skipReason) {
+      // Non-fatal: filesystem error checking existence
+      console.log(`      (round-trip check skipped: ${skipReason})`);
+      return;
+    }
+    if (!exists) {
+      // Non-fatal in isolation; fatal in the project's normal build environment.
+      // Log enough detail for diagnosis but do not fail the entire test run.
+      console.warn(`      WARNING: directory does not exist: ${projectDir}`);
+      console.warn(`      cwd=${cwd}`);
+      console.warn('      This is expected ONLY when running outside the pipeline project.');
+      // Intentionally not throwing — isolation mode.
+      return;
+    }
+    // If we reach here, the directory exists — assert it for clarity.
+    assert.ok(exists, `Expected ${projectDir} to exist on disk`);
+    console.log(`      confirmed: ${projectDir}`);
+  });
+
+  console.log('');
+  if (process.exitCode) {
+    console.error(`${passed} test(s) passed, 1 or more FAILED.`);
+  } else {
+    console.log(`All ${passed} test(s) passed.`);
+  }
+}

--- a/scripts/lib/shared.js
+++ b/scripts/lib/shared.js
@@ -155,7 +155,32 @@ function ollamaEmbed(texts, config) {
       res.on('end', () => {
         try {
           const parsed = JSON.parse(data);
-          if (!parsed.embeddings) return reject(new Error(`Ollama error: ${JSON.stringify(parsed).slice(0, 200)}`));
+          if (!parsed.embeddings || !Array.isArray(parsed.embeddings)) {
+            return reject(new Error(`Ollama error: ${JSON.stringify(parsed).slice(0, 200)}`));
+          }
+          if (parsed.embeddings.length !== texts.length) {
+            return reject(new Error(
+              `Ollama returned ${parsed.embeddings.length} embeddings for ${texts.length} inputs ` +
+              `(likely context overrun — chunk text smaller before retry)`
+            ));
+          }
+          for (let i = 0; i < parsed.embeddings.length; i++) {
+            const vec = parsed.embeddings[i];
+            if (!Array.isArray(vec) || vec.length === 0) {
+              return reject(new Error(
+                `Ollama returned empty embedding at index ${i} ` +
+                `(likely context overrun — chunk text smaller before retry)`
+              ));
+            }
+            let sumSquares = 0;
+            for (let j = 0; j < vec.length; j++) sumSquares += vec[j] * vec[j];
+            if (Math.sqrt(sumSquares) < 1e-9) {
+              return reject(new Error(
+                `Ollama returned zero-magnitude embedding at index ${i} ` +
+                `(likely context overrun — chunk text smaller before retry)`
+              ));
+            }
+          }
           resolve(parsed.embeddings);
         } catch (e) { reject(e); }
       });

--- a/scripts/pipeline-chunker.js
+++ b/scripts/pipeline-chunker.js
@@ -1,0 +1,342 @@
+'use strict';
+
+/**
+ * pipeline-chunker.js
+ *
+ * Pure-function text chunker for semantic embedding pipelines.
+ * No I/O. No DB. No file reads.
+ *
+ * Plan: docs/plans/2026-04-26-chunker-loader-plan.md
+ *
+ * @function chunkText
+ * @param {string} text          - Input text to split into chunks.
+ * @param {number} ceilingChars  - Hard maximum chars per chunk (default 1400).
+ *                                 Use 560 for JSONL/tool_result sources (DECISION-004).
+ * @param {string} contentType   - 'prose' (default) or 'tool_result'.
+ *                                 In 'tool_result' mode, rule 2 (code-fence) is the
+ *                                 primary split; rule 4 (sentence) is suppressed to
+ *                                 prevent splits on periods inside code expressions.
+ * @returns {Array<{content: string, chunkIdx: number}>}
+ *
+ * Boundary priority (first match wins within ceilingChars window):
+ *   1. Markdown heading  /^#{1,6}\s/m  - split BEFORE heading; heading starts new chunk.
+ *   2. Code-fence        /^```/m       - split at CLOSING fence; fence line ends chunk.
+ *   3. Paragraph break   double-newline - split at blank line.
+ *   4. Sentence break    [.!?] + space + uppercase - split after punctuation.
+ *   5. Hard-split at ceilingChars with overlap re-seed of Math.floor(ceilingChars * 0.14).
+ *
+ * In 'tool_result' mode: rule 2 fires first (before 1, 3, 4). Rule 4 never fires.
+ */
+
+const HEADING_RE = /^#{1,6} /m;
+const FENCE_RE   = /^```/m;
+
+/**
+ * @param {string} text
+ * @param {number} [ceilingChars=1400]
+ * @param {string} [contentType='prose']
+ * @returns {Array<{content: string, chunkIdx: number}>}
+ */
+function chunkText(text, ceilingChars, contentType) {
+  if (ceilingChars === undefined) ceilingChars = 1400;
+  if (contentType === undefined) contentType = 'prose';
+
+  if (!text || text.length === 0) return [];
+
+  const overlapSize = Math.floor(ceilingChars * 0.14);
+  const isToolResult = contentType === 'tool_result';
+
+  // Rule 1 pre-pass: always split on heading boundaries unconditionally.
+  // The heading line BEGINS the new section (split before it).
+  const sections = splitOnHeadings(text);
+
+  // For each heading-delimited section, apply rules 2-5 based on size.
+  const rawChunks = [];
+  for (const section of sections) {
+    chunkSection(section, ceilingChars, overlapSize, isToolResult, rawChunks);
+  }
+
+  // Renumber and drop empty chunks
+  const result = [];
+  for (const content of rawChunks) {
+    const trimmed = content.trimEnd();
+    if (trimmed.length > 0) {
+      result.push({ content: trimmed, chunkIdx: result.length });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Split text into sections at each markdown heading (rule 1).
+ * The heading line begins the new section.
+ * Returns an array of strings; each string is a heading + its body content.
+ */
+function splitOnHeadings(text) {
+  const lines = text.split('\n');
+  const sections = [];
+  let current = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Heading at i > 0: flush current section, start new one with this heading
+    if (i > 0 && HEADING_RE.test(line + '\n')) {
+      if (current.length > 0) {
+        sections.push(current.join('\n'));
+      }
+      current = [line];
+    } else {
+      current.push(line);
+    }
+  }
+  if (current.length > 0) {
+    sections.push(current.join('\n'));
+  }
+  return sections.length > 0 ? sections : [text];
+}
+
+/**
+ * Chunk a single section (already heading-bounded) using rules 2-5.
+ * Appends raw content strings to the out array.
+ */
+function chunkSection(text, ceilingChars, overlapSize, isToolResult, out) {
+  let remaining = text;
+  let overlapSeed = '';
+
+  while (remaining.length > 0) {
+    const workingText = overlapSeed + remaining;
+    overlapSeed = '';
+
+    if (workingText.length <= ceilingChars) {
+      const trimmed = workingText.trimEnd();
+      if (trimmed.length > 0) out.push(trimmed);
+      break;
+    }
+
+    const windowLen = ceilingChars;
+    let splitAt = -1;
+    let ruleUsed = 0;
+
+    if (isToolResult) {
+      // Rule 2 first in tool_result mode
+      splitAt = findClosingFence(workingText, windowLen);
+      if (splitAt > 0) ruleUsed = 2;
+    }
+
+    if (splitAt === -1 && !isToolResult) {
+      // Rule 2 in prose mode (after rule 1 which is handled by pre-pass)
+      splitAt = findClosingFence(workingText, windowLen);
+      if (splitAt > 0) ruleUsed = 2;
+    }
+
+    if (splitAt === -1) {
+      // Rule 3: paragraph break
+      const paraIdx = findParagraphBreak(workingText, windowLen);
+      if (paraIdx > 0) {
+        splitAt = paraIdx;
+        ruleUsed = 3;
+      }
+    }
+
+    if (splitAt === -1 && !isToolResult) {
+      // Rule 4: sentence break (suppressed in tool_result)
+      const sentIdx = findSentenceBreak(workingText, windowLen);
+      if (sentIdx > 0) {
+        splitAt = sentIdx;
+        ruleUsed = 4;
+      }
+    }
+
+    if (splitAt === -1) {
+      // Rule 5: hard split with overlap seed
+      ruleUsed = 5;
+      splitAt = ceilingChars;
+      overlapSeed = workingText.slice(splitAt - overlapSize, splitAt);
+    }
+
+    const chunk = workingText.slice(0, splitAt).trimEnd();
+    if (chunk.length > 0) out.push(chunk);
+
+    remaining = workingText.slice(splitAt);
+
+    // Strip leading newlines after non-heading splits
+    if (ruleUsed !== 1) {
+      remaining = remaining.replace(/^\n+/, '');
+    }
+  }
+}
+
+/**
+ * Find a closing code-fence within window.
+ * Returns the index just after the closing fence line so the fence ends the chunk.
+ */
+function findClosingFence(text, windowLen) {
+  const sub = text.slice(0, windowLen);
+  const lines = sub.split('\n');
+  let pos = 0;
+  let inFence = false;
+  let closingFenceEnd = -1;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (FENCE_RE.test(line)) {
+      if (!inFence) {
+        inFence = true;
+      } else {
+        closingFenceEnd = pos + line.length + 1;
+        inFence = false;
+      }
+    }
+    pos += line.length + 1;
+  }
+  return closingFenceEnd;
+}
+
+/**
+ * Find the last paragraph break within window.
+ * Returns the index just after the double-newline.
+ */
+function findParagraphBreak(text, windowLen) {
+  const sub = text.slice(0, windowLen);
+  const idx = sub.lastIndexOf('\n\n');
+  if (idx === -1) return -1;
+  return idx + 2;
+}
+
+/**
+ * Find the last sentence break within window.
+ * Split after the punctuation char.
+ */
+function findSentenceBreak(text, windowLen) {
+  const sub = text.slice(0, windowLen);
+  const re = /[.!?](?=\s+[A-Z])/g;
+  let lastIdx = -1;
+  let m;
+  while ((m = re.exec(sub)) !== null) {
+    lastIdx = m.index + 1;
+  }
+  return lastIdx;
+}
+
+module.exports = { chunkText };
+
+// ---------------------------------------------------------------------------
+// Inline tests -- run with: node scripts/pipeline-chunker.js
+// ---------------------------------------------------------------------------
+if (require.main === module) {
+  const assert = require('assert');
+  let testCount = 0;
+
+  function test(name, fn) {
+    fn();
+    testCount++;
+  }
+
+  // Test 1: Empty input returns [].
+  test('empty input returns []', function() {
+    assert.deepStrictEqual(chunkText(''), [], 'empty string should return []');
+    assert.deepStrictEqual(chunkText('', 1400), [], 'empty with ceiling should return []');
+  });
+
+  // Test 2: Short input returns one chunk with chunkIdx 0.
+  test('short input returns single chunk', function() {
+    const input = 'Hello world. This is a short input under 50 chars.';
+    const result = chunkText(input, 1400);
+    assert.strictEqual(result.length, 1, 'short input should produce exactly 1 chunk');
+    assert.strictEqual(result[0].chunkIdx, 0, 'single chunk should have chunkIdx 0');
+    assert.strictEqual(result[0].content, input.trimEnd(), 'content should match trimmed input');
+  });
+
+  // Test 3: Two H2 headings produce 2 chunks (chunkIdx 0 and 1).
+  test('two H2 headings produce 2 chunks', function() {
+    const h1 = '## First Heading';
+    const h2 = '## Second Heading';
+    const input = h1 + '\n\nSome content here.\n\n' + h2 + '\n\nMore content.';
+    const result = chunkText(input, 1400);
+    assert.strictEqual(result.length, 2, 'expected 2 chunks for 2 headings, got ' + result.length);
+    assert.strictEqual(result[0].chunkIdx, 0, 'first chunk chunkIdx should be 0');
+    assert.strictEqual(result[1].chunkIdx, 1, 'second chunk chunkIdx should be 1');
+    assert.ok(result[0].content.startsWith(h1),
+      'first chunk should start with ## First Heading');
+    assert.ok(result[1].content.startsWith(h2),
+      'second chunk should start with ## Second Heading');
+  });
+
+  // Test 4: 1500-char string with para break around 800 produces 2 chunks both <= 1400.
+  test('1500-char string with para break around 800 produces 2 chunks', function() {
+    const part1 = 'A'.repeat(790) + '\n\n';
+    const part2 = 'B'.repeat(700);
+    const input = part1 + part2;
+    assert.ok(input.length > 1400, 'input should be >1400 chars, got ' + input.length);
+    const result = chunkText(input, 1400);
+    assert.strictEqual(result.length, 2, 'expected 2 chunks, got ' + result.length);
+    assert.ok(result[0].content.length <= 1400, 'chunk 0 length exceeds 1400: ' + result[0].content.length);
+    assert.ok(result[1].content.length <= 1400, 'chunk 1 length exceeds 1400: ' + result[1].content.length);
+  });
+
+  // Test 5: prose + fenced code block + prose; fence content preserved intact.
+  test('fenced code block content preserved across chunks', function() {
+    const prose1 = 'Leading prose paragraph sets up context.\n\n';
+    const fenceBody = 'const x = 1;\n'.repeat(4);
+    const bt = String.fromCharCode(96).repeat(3);
+    const fence = bt + 'js\n' + fenceBody + bt + '\n\n';
+    const prose2 = 'Trailing prose paragraph wraps things up.\n\n';
+    const input = prose1 + fence + prose2;
+    const result = chunkText(input, 300);
+    assert.ok(result.length >= 1, 'should produce at least 1 chunk');
+    const joined = result.map(function(c) { return c.content; }).join('\n');
+    assert.ok(joined.includes('const x = 1;'), 'fence content should be preserved in chunks');
+    assert.ok(joined.includes(bt + 'js'), 'opening fence marker should be preserved');
+  });
+
+  // Test 6: 3000-char no-whitespace string forces rule 5 with overlap.
+  test('3000-char no-whitespace string hard-splits with overlap', function() {
+    const input = 'x'.repeat(3000);
+    const result = chunkText(input, 1400);
+    assert.ok(result.length >= 2, 'expected >= 2 chunks, got ' + result.length);
+    for (let i = 0; i < result.length; i++) {
+      assert.ok(result[i].content.length <= 1400,
+        'chunk ' + i + ' length ' + result[i].content.length + ' exceeds ceiling');
+    }
+    const overlapSize = Math.floor(1400 * 0.14);
+    const expectedOverlap = result[0].content.slice(-overlapSize);
+    assert.ok(result[1].content.startsWith(expectedOverlap),
+      'chunk 1 should start with last ' + overlapSize + ' chars of chunk 0 (overlap seed)');
+  });
+
+  // Test 7: tool_result mode - splits on fence, not on period inside code.
+  test('tool_result mode splits on fence boundary not sentence period', function() {
+    const longProse = 'This is leading text that explains the tool result context. '.repeat(8);
+    const bt = String.fromCharCode(96).repeat(3);
+    const code = bt + 'js\nconst x = 1;\nconst y = 2;\n' + bt + '\n';
+    const moreProse = 'Additional explanation follows here.';
+    const input = longProse + code + moreProse;
+    const result = chunkText(input, 200, 'tool_result');
+    assert.ok(result.length >= 1, 'should produce at least 1 chunk');
+    const joined = result.map(function(c) { return c.content; }).join('\n');
+    assert.ok(joined.includes('const x = 1;'), 'const x = 1; should be intact in tool_result mode');
+    assert.ok(joined.includes('const y = 2;'), 'const y = 2; should be intact in tool_result mode');
+  });
+
+  // Test 8: tiny ceiling forces rule 5; produces multiple chunks each <= 5 chars.
+  test('tiny ceiling forces rule 5 hard splits', function() {
+    const result = chunkText('hello world.', 5);
+    assert.ok(result.length > 1, 'expected multiple chunks with ceiling=5, got ' + result.length);
+    for (let i = 0; i < result.length; i++) {
+      assert.ok(result[i].content.length <= 5,
+        'chunk ' + i + ' length ' + result[i].content.length + ' exceeds ceiling of 5');
+    }
+  });
+
+  // Test 9: 560 ceiling produces strictly more chunks than 1400.
+  test('560 ceiling produces strictly more chunks than 1400', function() {
+    const para = 'This is a paragraph of reasonable length. It contains multiple sentences. ';
+    const input = (para.repeat(5) + '\n\n').repeat(4);
+    const result1400 = chunkText(input, 1400);
+    const result560  = chunkText(input, 560);
+    assert.ok(result560.length > result1400.length,
+      '560-ceiling (' + result560.length + ' chunks) should exceed 1400-ceiling (' + result1400.length + ' chunks)');
+  });
+
+  console.log('chunker tests passed (' + testCount + ' tests)');
+}

--- a/scripts/pipeline-embed.js
+++ b/scripts/pipeline-embed.js
@@ -281,6 +281,9 @@ async function cmdAdd(filepath, description) {
 async function cmdSearch(query) {
   console.log(`${c.bold('Semantic search:')} "${query}"\n`);
 
+  // Tables covered by v_memory_hits — queried via the view, not directly
+  const MEMORY_HITS_COVERED = new Set(['memory_entries', 'session_chunks', 'policy_sections', 'memory_entry_chunks']);
+
   const client = await connect(CONFIG);
   try {
     // Pre-check: is there anything to search?
@@ -298,7 +301,39 @@ async function cmdSearch(query) {
 
     let resultNum = 0;
 
+    // ── v_memory_hits (chunked: memory + sessions + policy) ──
+    const { rows: viewExists } = await client.query(
+      "SELECT 1 FROM pg_views WHERE viewname = 'v_memory_hits' LIMIT 1"
+    );
+    if (!viewExists.length) {
+      console.log(c.yellow('  (v_memory_hits view not found — run setup to enable chunked memory search)'));
+    } else {
+      const { rows: viewRows } = await client.query(
+        `SELECT source_table, chunk_id, source_row_id, source_ordinal, chunk_idx, total_chunks, label, snippet,
+                1 - (embedding <=> $1::vector) AS cosine_similarity
+         FROM v_memory_hits
+         WHERE embedding IS NOT NULL
+         ORDER BY embedding <=> $1::vector
+         LIMIT 5`,
+        [vec]
+      );
+      if (viewRows.length > 0) {
+        console.log(c.bold('── memory (chunked: memory + sessions + policy) ──'));
+        viewRows.forEach((row) => {
+          resultNum++;
+          const score = (row.cosine_similarity * 100).toFixed(1);
+          const chunkLabel = row.total_chunks > 1
+            ? ` (chunk ${row.chunk_idx + 1}/${row.total_chunks})`
+            : '';
+          const snippet = (row.snippet || '').substring(0, 120).replace(/\n/g, ' ');
+          console.log(`${c.cyan(String(resultNum).padStart(2))}. ${c.bold(`[${row.source_table}] ${row.label}${chunkLabel}`)} ${c.dim(`(${score}%)`)}`);
+          console.log(`    ${snippet}...\n`);
+        });
+      }
+    }
+
     for (const tbl of TABLES) {
+      if (MEMORY_HITS_COVERED.has(tbl.name)) continue;
       if (!(await tableExists(client, tbl.name))) continue;
 
       const { rows: [{ count }] } = await client.query(`SELECT COUNT(*) FROM ${tbl.name}`);
@@ -339,12 +374,49 @@ async function cmdSearch(query) {
 async function cmdHybrid(query) {
   console.log(`${c.bold('Hybrid search:')} "${query}"\n`);
 
+  // Tables covered by v_memory_hits — queried via the view, not directly
+  const MEMORY_HITS_COVERED = new Set(['memory_entries', 'session_chunks', 'policy_sections', 'memory_entry_chunks']);
+
   const client = await connect(CONFIG);
   try {
     let resultNum = 0;
     let qEmb = null;
 
+    // ── v_memory_hits (chunked: memory + sessions + policy) ──
+    const { rows: viewExists } = await client.query(
+      "SELECT 1 FROM pg_views WHERE viewname = 'v_memory_hits' LIMIT 1"
+    );
+    if (!viewExists.length) {
+      console.log(c.yellow('  (v_memory_hits view not found — run setup to enable chunked memory search)'));
+    } else {
+      if (!qEmb) { [qEmb] = await ollamaEmbed([query], CONFIG); }
+      const vec = `[${qEmb.join(',')}]`;
+      const { rows: viewRows } = await client.query(
+        `SELECT source_table, chunk_id, source_row_id, source_ordinal, chunk_idx, total_chunks, label, snippet,
+                ts_rank(fts_vec, plainto_tsquery($1)) * 0.3 +
+                (1 - (embedding <=> $2::vector)) * 0.7 AS score
+         FROM v_memory_hits
+         WHERE embedding IS NOT NULL
+         ORDER BY score DESC
+         LIMIT 5`,
+        [query, vec]
+      );
+      if (viewRows.length > 0) {
+        console.log(c.bold('── memory (chunked: memory + sessions + policy) ──'));
+        viewRows.forEach((row) => {
+          resultNum++;
+          const chunkLabel = row.total_chunks > 1
+            ? ` (chunk ${row.chunk_idx + 1}/${row.total_chunks})`
+            : '';
+          const snippet = (row.snippet || '').substring(0, 120).replace(/\n/g, ' ');
+          console.log(`${c.cyan(String(resultNum).padStart(2))}. ${c.bold(`[${row.source_table}] ${row.label}${chunkLabel}`)} ${c.dim(`(${(row.score * 100).toFixed(1)}%)`)}`);
+          console.log(`    ${snippet}...\n`);
+        });
+      }
+    }
+
     for (const tbl of TABLES) {
+      if (MEMORY_HITS_COVERED.has(tbl.name)) continue;
       if (!(await tableExists(client, tbl.name))) continue;
 
       const { rows: [{ count }] } = await client.query(`SELECT COUNT(*) FROM ${tbl.name}`);

--- a/scripts/pipeline-memory-loader.js
+++ b/scripts/pipeline-memory-loader.js
@@ -124,6 +124,12 @@ function sha256(text) {
 async function embedPending(db, config, table, buildCtx, stats) {
   if (dryRun || !db) return;
 
+  // Allowlist guard — prevent arbitrary table names from reaching SQL
+  const ALLOWED_TABLES = new Set(['memory_entry_chunks', 'session_chunks', 'policy_sections']);
+  if (!ALLOWED_TABLES.has(table)) {
+    throw new Error(`embedPending called with disallowed table: ${table}`);
+  }
+
   // Fetch pending rows — join to parent table for context prefix where needed
   let rows;
   if (table === 'memory_entry_chunks') {
@@ -147,21 +153,35 @@ async function embedPending(db, config, table, buildCtx, stats) {
   for (let i = 0; i < rows.length; i += BATCH) {
     const batch = rows.slice(i, i + BATCH);
     const texts = batch.map(buildCtx);
-    const ids   = batch.map(r => r.id);
 
     try {
       const embeddings = await ollamaEmbed(texts, config && config.knowledge);
+      // Happy path: write all embeddings in the batch
       for (let j = 0; j < batch.length; j++) {
         const vec = `[${embeddings[j].join(',')}]`;
         await db.query(
           `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
-          [vec, ids[j]]
+          [vec, batch[j].id]
         );
         stats.embedded++;
       }
-    } catch (err) {
-      console.error(`  [EMBED ERROR] table=${table} ids=[${ids.join(',')}] err=${err.message}`);
-      stats.errored += batch.length;
+    } catch (batchErr) {
+      // Batch-level failure: fall back to per-chunk individual retry so that
+      // a single oversized chunk doesn't mark healthy chunks as errored.
+      for (let j = 0; j < batch.length; j++) {
+        try {
+          const [vec1] = await ollamaEmbed([texts[j]], config && config.knowledge);
+          const vec = `[${vec1.join(',')}]`;
+          await db.query(
+            `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
+            [vec, batch[j].id]
+          );
+          stats.embedded++;
+        } catch (chunkErr) {
+          stats.errored++;
+          console.error(c.red(`  embed error: table=${table} id=${batch[j].id} chunk_idx=${batch[j].chunk_idx} :: ${chunkErr.message.slice(0, 100)}`));
+        }
+      }
     }
   }
 }
@@ -245,11 +265,12 @@ async function loadMemory(db, config) {
         const stored = existingHashes.get(chunk.chunkIdx);
 
         if (!force && stored === hash) {
-          // Hash match and not forced — preserve existing embedding, skip re-embed
+          // Hash match and not forced — row already exists; ON CONFLICT DO NOTHING
+          // preserves the existing row (including its embedding) unchanged.
           stats.skipped++;
           await db.query(
-            `INSERT INTO memory_entry_chunks (entry_id, chunk_idx, content, content_hash, embedding)
-             VALUES ($1, $2, $3, $4, (SELECT embedding FROM memory_entry_chunks WHERE entry_id = $1 AND chunk_idx = $2))
+            `INSERT INTO memory_entry_chunks (entry_id, chunk_idx, content, content_hash)
+             VALUES ($1, $2, $3, $4)
              ON CONFLICT (entry_id, chunk_idx) DO NOTHING`,
             [entryId, chunk.chunkIdx, chunk.content, hash]
           );
@@ -359,7 +380,17 @@ async function loadSessions(db, config) {
         if (subChunks.length === 0) subChunks.push(content.slice(0, CONST_JSONL_CEILING));
       } else if (Array.isArray(content)) {
         for (const el of content) {
-          const str = typeof el === 'string' ? el : JSON.stringify(el);
+          // Skip non-text elements (images, tool_use refs, tool_result refs) —
+          // they carry no retrievable text and would bloat the chunk store.
+          let str;
+          if (typeof el === 'string') {
+            str = el;
+          } else if (el && typeof el === 'object' && el.type === 'text' && typeof el.text === 'string') {
+            str = el.text;
+          } else {
+            // Non-text element (image, tool_use, tool_result, etc.) — skip
+            continue;
+          }
           if (str.trim().length === 0) continue;
           const pieces = chunkText(str, CONST_JSONL_CEILING, 'prose');
           for (const p of pieces) subChunks.push(p.content);

--- a/scripts/pipeline-memory-loader.js
+++ b/scripts/pipeline-memory-loader.js
@@ -1,0 +1,583 @@
+'use strict';
+
+/**
+ * pipeline-memory-loader.js
+ *
+ * CLI loader: reads filesystem sources, chunks via pipeline-chunker, embeds
+ * via ollamaEmbed (BATCH=8), and upserts idempotently into the three chunk tables.
+ *
+ * Usage:
+ *   node scripts/pipeline-memory-loader.js memory      # Load ~/.claude/projects/<cwd>/memory/*.md
+ *   node scripts/pipeline-memory-loader.js sessions    # Load ~/.claude/projects/<cwd>/*.jsonl
+ *   node scripts/pipeline-memory-loader.js policy      # Load project + global CLAUDE.md
+ *   node scripts/pipeline-memory-loader.js all         # All three in sequence
+ *   node scripts/pipeline-memory-loader.js help        # Help text
+ *
+ * Flags (apply to any subcommand):
+ *   --force      Bypass content_hash skip; re-embed all chunks
+ *   --dry-run    Read sources, compute chunks, print summary; no DB writes
+ *
+ * Exit codes: 0 on success, 1 on any error.
+ *
+ * Plan: docs/plans/2026-04-26-chunker-loader-plan.md (Phase 5)
+ */
+
+const fs     = require('fs');
+const path   = require('path');
+const os     = require('os');
+const crypto = require('crypto');
+
+const { chunkText }          = require('./pipeline-chunker');
+const { getClaudeProjectDir } = require('./lib/encoded-cwd');
+const { loadConfig, connect, c, ollamaEmbed } = require('./lib/shared');
+
+const BATCH                = 8;
+const CONST_PROSE_CEILING  = 1400;  // DECISION-004: prose sources
+const CONST_JSONL_CEILING  = 560;   // DECISION-004: JSONL/tool_result sources
+
+// ─── ARGUMENT PARSING ────────────────────────────────────────────────────────
+
+const args    = process.argv.slice(2);
+const subcmd  = args.find(a => !a.startsWith('--')) || '';
+const force   = args.includes('--force');
+const dryRun  = args.includes('--dry-run');
+
+// ─── MAIN ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  if (!subcmd || subcmd === 'help') {
+    printHelp();
+    process.exit(0);
+  }
+
+  const validCmds = ['memory', 'sessions', 'policy', 'all'];
+  if (!validCmds.includes(subcmd)) {
+    console.error(`Unknown subcommand: ${subcmd}`);
+    printHelp();
+    process.exit(1);
+  }
+
+  let config, db;
+  if (!dryRun) {
+    try {
+      config = loadConfig();
+      db     = await connect(config);
+    } catch (err) {
+      console.error(`DB connection failed: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  try {
+    if (subcmd === 'memory' || subcmd === 'all') await loadMemory(db, config);
+    if (subcmd === 'sessions' || subcmd === 'all') await loadSessions(db, config);
+    if (subcmd === 'policy' || subcmd === 'all') await loadPolicy(db, config);
+  } catch (err) {
+    console.error(`Loader failed: ${err.message}`);
+    if (db) await db.end().catch(() => {});
+    process.exit(1);
+  }
+
+  if (db) await db.end().catch(() => {});
+}
+
+function printHelp() {
+  console.log([
+    '',
+    'pipeline-memory-loader.js — embed memory, sessions, and policy into the knowledge DB',
+    '',
+    'Usage:',
+    '  node scripts/pipeline-memory-loader.js <subcommand> [flags]',
+    '',
+    'Subcommands:',
+    '  memory    Load ~/.claude/projects/<cwd>/memory/*.md',
+    '  sessions  Load ~/.claude/projects/<cwd>/*.jsonl',
+    '  policy    Load project CLAUDE.md and global ~/.claude/CLAUDE.md',
+    '  all       Run memory, sessions, and policy in sequence',
+    '  help      Show this help text',
+    '',
+    'Flags:',
+    '  --force    Bypass content_hash skip; re-embed all chunks',
+    '  --dry-run  Read sources and compute chunks; no DB writes',
+    '',
+  ].join('\n'));
+}
+
+// ─── SHA256 HELPER ───────────────────────────────────────────────────────────
+
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+// ─── EMBED PENDING HELPER ────────────────────────────────────────────────────
+
+/**
+ * Embed all rows with NULL embedding in a given table.
+ * Selects rows, groups into BATCH=8 windows, calls ollamaEmbed, writes back.
+ *
+ * @param {object}   db       - pg Client (null in dry-run mode)
+ * @param {object}   config   - pipeline config (for embedding_model)
+ * @param {string}   table    - 'memory_entry_chunks' | 'policy_sections' | 'session_chunks'
+ * @param {Function} buildCtx - (row) => string — context-prefixed text for embedding
+ * @param {object}   stats    - mutable stats object with .embedded / .errored keys
+ */
+async function embedPending(db, config, table, buildCtx, stats) {
+  if (dryRun || !db) return;
+
+  // Fetch pending rows — join to parent table for context prefix where needed
+  let rows;
+  if (table === 'memory_entry_chunks') {
+    const r = await db.query(
+      `SELECT mc.id, mc.content, me.name
+       FROM memory_entry_chunks mc
+       JOIN memory_entries me ON me.id = mc.entry_id
+       WHERE mc.embedding IS NULL
+       ORDER BY mc.id`
+    );
+    rows = r.rows;
+  } else {
+    const r = await db.query(
+      `SELECT * FROM ${table} WHERE embedding IS NULL ORDER BY id`
+    );
+    rows = r.rows;
+  }
+
+  if (rows.length === 0) return;
+
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const batch = rows.slice(i, i + BATCH);
+    const texts = batch.map(buildCtx);
+    const ids   = batch.map(r => r.id);
+
+    try {
+      const embeddings = await ollamaEmbed(texts, config && config.knowledge);
+      for (let j = 0; j < batch.length; j++) {
+        const vec = `[${embeddings[j].join(',')}]`;
+        await db.query(
+          `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
+          [vec, ids[j]]
+        );
+        stats.embedded++;
+      }
+    } catch (err) {
+      console.error(`  [EMBED ERROR] table=${table} ids=[${ids.join(',')}] err=${err.message}`);
+      stats.errored += batch.length;
+    }
+  }
+}
+
+// ─── MEMORY LOADER ───────────────────────────────────────────────────────────
+
+async function loadMemory(db, config) {
+  const start   = Date.now();
+  const memDir  = path.join(getClaudeProjectDir(process.cwd()), 'memory');
+  const stats   = { files: 0, parents: 0, chunks: 0, embedded: 0, skipped: 0, errors: 0 };
+
+  let files;
+  try {
+    files = fs.readdirSync(memDir).filter(f => f.endsWith('.md'));
+  } catch (err) {
+    console.error(`memory loader: cannot read directory ${memDir}: ${err.message}`);
+    stats.errors++;
+    printMemoryStats(stats, Date.now() - start);
+    return;
+  }
+
+  for (const filename of files) {
+    const filePath  = path.join(memDir, filename);
+    const name      = filename.slice(0, -3); // strip .md
+    const sourceFile = path.join('memory', filename);
+
+    let body;
+    try {
+      body = fs.readFileSync(filePath, 'utf8');
+    } catch (err) {
+      console.error(`  [SKIP] Cannot read ${filePath}: ${err.message}`);
+      stats.errors++;
+      continue;
+    }
+
+    stats.files++;
+
+    // Parse first non-empty line for description (must start with "# ")
+    const firstLine = body.split('\n').find(l => l.trim().length > 0) || '';
+    const description = firstLine.startsWith('# ')
+      ? firstLine.slice(2).trim()
+      : null;
+
+    // Parse YAML frontmatter for mem_type (simple key: value scan)
+    let memType = null;
+    const fmMatch = body.match(/^---\s*\n([\s\S]*?)\n---/);
+    if (fmMatch) {
+      const typeMatch = fmMatch[1].match(/^type:\s*(.+)$/m);
+      if (typeMatch) memType = typeMatch[1].trim();
+    }
+
+    if (!dryRun) {
+      // Upsert parent row — conflict on source_file (the UNIQUE column)
+      const parentRes = await db.query(
+        `INSERT INTO memory_entries (name, description, mem_type, body, source_file)
+         VALUES ($1, $2, $3, $4, $5)
+         ON CONFLICT (source_file) DO UPDATE
+           SET name        = EXCLUDED.name,
+               description = EXCLUDED.description,
+               mem_type    = EXCLUDED.mem_type,
+               body        = EXCLUDED.body,
+               updated_at  = NOW()
+         RETURNING id`,
+        [name, description, memType, body, sourceFile]
+      );
+      const entryId = parentRes.rows[0].id;
+      stats.parents++;
+
+      // Chunk and upsert chunks
+      const chunks = chunkText(body, CONST_PROSE_CEILING, 'prose');
+
+      // Fetch existing content_hashes for this entry to detect skip candidates
+      const existRes = await db.query(
+        `SELECT chunk_idx, content_hash FROM memory_entry_chunks WHERE entry_id = $1`,
+        [entryId]
+      );
+      const existingHashes = new Map(existRes.rows.map(r => [r.chunk_idx, r.content_hash]));
+
+      for (const chunk of chunks) {
+        const hash = sha256(chunk.content);
+        const stored = existingHashes.get(chunk.chunkIdx);
+
+        if (!force && stored === hash) {
+          // Hash match and not forced — preserve existing embedding, skip re-embed
+          stats.skipped++;
+          await db.query(
+            `INSERT INTO memory_entry_chunks (entry_id, chunk_idx, content, content_hash, embedding)
+             VALUES ($1, $2, $3, $4, (SELECT embedding FROM memory_entry_chunks WHERE entry_id = $1 AND chunk_idx = $2))
+             ON CONFLICT (entry_id, chunk_idx) DO NOTHING`,
+            [entryId, chunk.chunkIdx, chunk.content, hash]
+          );
+        } else {
+          // New or changed chunk — upsert with NULL embedding to trigger re-embed
+          await db.query(
+            `INSERT INTO memory_entry_chunks (entry_id, chunk_idx, content, content_hash, embedding)
+             VALUES ($1, $2, $3, $4, NULL)
+             ON CONFLICT (entry_id, chunk_idx) DO UPDATE
+               SET content      = EXCLUDED.content,
+                   content_hash = EXCLUDED.content_hash,
+                   embedding    = NULL`,
+            [entryId, chunk.chunkIdx, chunk.content, hash]
+          );
+        }
+        stats.chunks++;
+      }
+    } else {
+      // dry-run: count only
+      const chunks = chunkText(body, CONST_PROSE_CEILING, 'prose');
+      stats.parents++;
+      stats.chunks += chunks.length;
+    }
+  }
+
+  // Embed pass — all NULL embedding rows for memory_entry_chunks
+  if (!dryRun) {
+    await embedPending(db, config, 'memory_entry_chunks',
+      row => `Memory: ${row.name}\n\n${row.content}`,
+      stats
+    );
+  }
+
+  printMemoryStats(stats, Date.now() - start);
+}
+
+function printMemoryStats(stats, ms) {
+  console.log(`memory loader:`);
+  console.log(`  Files read:        ${stats.files}`);
+  console.log(`  Parents upserted:  ${stats.parents}`);
+  console.log(`  Chunks upserted:   ${stats.chunks}`);
+  console.log(`  Chunks embedded:   ${stats.embedded}`);
+  console.log(`  Chunks skipped (hash match, --force not set): ${stats.skipped}`);
+  console.log(`  Errors:            ${stats.errors}`);
+  console.log(`  Duration:          ${(ms / 1000).toFixed(1)}s`);
+  if (dryRun) console.log(`  (dry-run: no DB writes)`);
+}
+
+// ─── SESSIONS LOADER ─────────────────────────────────────────────────────────
+
+async function loadSessions(db, config) {
+  const start      = Date.now();
+  const projectDir = getClaudeProjectDir(process.cwd());
+  const stats      = { files: 0, chunks: 0, embedded: 0, skipped: 0, errors: 0 };
+
+  // NOTE: session_chunks has NO unique constraint on (session_id, chunk_idx).
+  // The table only has a PRIMARY KEY on id. We use INSERT ... WHERE NOT EXISTS
+  // to avoid duplicates on re-run, and UPDATE the embedding=NULL when content
+  // changes (detected via content_hash comparison before insert).
+  // See schema audit: scripts/setup-knowledge-db.sql ~line 448.
+
+  let jsonlFiles;
+  try {
+    jsonlFiles = fs.readdirSync(projectDir)
+      .filter(f => f.endsWith('.jsonl'))
+      .map(f => path.join(projectDir, f));
+  } catch (err) {
+    console.error(`sessions loader: cannot read directory ${projectDir}: ${err.message}`);
+    stats.errors++;
+    printSessionStats(stats, Date.now() - start);
+    return;
+  }
+
+  for (const filePath of jsonlFiles) {
+    const filename  = path.basename(filePath);
+    const sessionId = filename.slice(0, -6); // strip .jsonl
+
+    let lines;
+    try {
+      lines = fs.readFileSync(filePath, 'utf8').split('\n').filter(l => l.trim());
+    } catch (err) {
+      console.error(`  [SKIP] Cannot read ${filePath}: ${err.message}`);
+      stats.errors++;
+      continue;
+    }
+
+    stats.files++;
+    let chunkIdx = 0;
+
+    for (const line of lines) {
+      let msg;
+      try { msg = JSON.parse(line); } catch { continue; }
+
+      const role    = msg.role || msg.type || '';
+      const content = msg.content;
+
+      if (!content) continue;
+
+      // Build sub-chunks for this message
+      const subChunks = [];
+
+      if (typeof content === 'string') {
+        if (content.length === 0) continue;
+        const contentType = role === 'tool_result' ? 'tool_result' : 'prose';
+        const pieces = chunkText(content, CONST_JSONL_CEILING, contentType);
+        for (const p of pieces) subChunks.push(p.content);
+        if (subChunks.length === 0) subChunks.push(content.slice(0, CONST_JSONL_CEILING));
+      } else if (Array.isArray(content)) {
+        for (const el of content) {
+          const str = typeof el === 'string' ? el : JSON.stringify(el);
+          if (str.trim().length === 0) continue;
+          const pieces = chunkText(str, CONST_JSONL_CEILING, 'prose');
+          for (const p of pieces) subChunks.push(p.content);
+          if (pieces.length === 0 && str.trim()) subChunks.push(str.slice(0, CONST_JSONL_CEILING));
+        }
+      } else {
+        continue;
+      }
+
+      for (const chunkContent of subChunks) {
+        if (!chunkContent.trim()) { chunkIdx++; continue; }
+        const hash = sha256(chunkContent);
+
+        if (!dryRun) {
+          // Check existing row for this session_id + chunk_idx
+          const existRes = await db.query(
+            `SELECT id, content_hash, embedding FROM session_chunks
+             WHERE session_id = $1 AND chunk_idx = $2
+             LIMIT 1`,
+            [sessionId, chunkIdx]
+          );
+
+          if (existRes.rows.length === 0) {
+            // New chunk — insert
+            await db.query(
+              `INSERT INTO session_chunks
+                 (session_id, chunk_idx, chunk_kind, content, content_hash, source_jsonl)
+               VALUES ($1, $2, $3, $4, $5, $6)`,
+              [sessionId, chunkIdx, role, chunkContent, hash, filePath]
+            );
+          } else {
+            const existing = existRes.rows[0];
+            if (!force && existing.content_hash === hash) {
+              // Hash match — preserve embedding, skip re-embed
+              stats.skipped++;
+            } else {
+              // Changed content — update with NULL embedding to trigger re-embed
+              await db.query(
+                `UPDATE session_chunks
+                 SET content = $1, content_hash = $2, chunk_kind = $3,
+                     embedding = NULL, source_jsonl = $4
+                 WHERE id = $5`,
+                [chunkContent, hash, role, filePath, existing.id]
+              );
+            }
+          }
+        }
+
+        stats.chunks++;
+        chunkIdx++;
+      }
+    }
+  }
+
+  // Embed pass
+  if (!dryRun) {
+    await embedPending(db, config, 'session_chunks',
+      row => `Session: ${row.session_id} [${row.chunk_kind || ''}]\n\n${row.content}`,
+      stats
+    );
+  }
+
+  printSessionStats(stats, Date.now() - start);
+}
+
+function printSessionStats(stats, ms) {
+  console.log(`sessions loader:`);
+  console.log(`  Files read:        ${stats.files}`);
+  console.log(`  Chunks upserted:   ${stats.chunks}`);
+  console.log(`  Chunks embedded:   ${stats.embedded}`);
+  console.log(`  Chunks skipped (hash match, --force not set): ${stats.skipped}`);
+  console.log(`  Errors:            ${stats.errors}`);
+  console.log(`  Duration:          ${(ms / 1000).toFixed(1)}s`);
+  if (dryRun) console.log(`  (dry-run: no DB writes)`);
+}
+
+// ─── POLICY LOADER ───────────────────────────────────────────────────────────
+
+async function loadPolicy(db, config) {
+  const start   = Date.now();
+  const sources = [
+    { docId: 'CLAUDE.md',        filePath: path.join(process.cwd(), 'CLAUDE.md') },
+    { docId: 'global-CLAUDE.md', filePath: path.join(os.homedir(), '.claude', 'CLAUDE.md') },
+  ];
+  const stats = { files: 0, sections: 0, chunks: 0, embedded: 0, skipped: 0, errors: 0 };
+
+  for (const { docId, filePath } of sources) {
+    if (!fs.existsSync(filePath)) continue;
+
+    let body;
+    try {
+      body = fs.readFileSync(filePath, 'utf8');
+    } catch (err) {
+      console.error(`  [SKIP] Cannot read ${filePath}: ${err.message}`);
+      stats.errors++;
+      continue;
+    }
+
+    stats.files++;
+
+    // Split on heading boundaries — each heading starts a new section
+    const sections = splitPolicySections(body);
+
+    for (const section of sections) {
+      const subChunks = chunkText(section.content, CONST_PROSE_CEILING, 'prose');
+      stats.sections++;
+
+      for (const chunk of subChunks) {
+        const hash = sha256(chunk.content);
+
+        if (!dryRun) {
+          // Check for existing row
+          const existRes = await db.query(
+            `SELECT id, content_hash FROM policy_sections
+             WHERE doc_id = $1 AND section_num = $2 AND chunk_idx = $3
+             LIMIT 1`,
+            [docId, section.sectionNum, chunk.chunkIdx]
+          );
+
+          if (existRes.rows.length === 0) {
+            // New — insert
+            await db.query(
+              `INSERT INTO policy_sections
+                 (doc_id, section_num, section_title, content, chunk_idx, content_hash)
+               VALUES ($1, $2, $3, $4, $5, $6)`,
+              [docId, section.sectionNum, section.sectionTitle, chunk.content, chunk.chunkIdx, hash]
+            );
+          } else {
+            const existing = existRes.rows[0];
+            if (!force && existing.content_hash === hash) {
+              stats.skipped++;
+            } else {
+              await db.query(
+                `UPDATE policy_sections
+                 SET section_title = $1, content = $2, content_hash = $3, embedding = NULL
+                 WHERE id = $4`,
+                [section.sectionTitle, chunk.content, hash, existing.id]
+              );
+            }
+          }
+        }
+
+        stats.chunks++;
+      }
+    }
+  }
+
+  // Embed pass
+  if (!dryRun) {
+    await embedPending(db, config, 'policy_sections',
+      row => `Policy: ${row.doc_id} §${row.section_num || ''} ${row.section_title || ''}\n\n${row.content}`,
+      stats
+    );
+  }
+
+  printPolicyStats(stats, Date.now() - start);
+}
+
+/**
+ * Split a policy document body into sections at heading boundaries.
+ * Each section has: sectionNum (string, e.g. "1.2"), sectionTitle (string), content (string).
+ * sectionNum is based on heading level counters (hierarchical dotted notation).
+ */
+function splitPolicySections(body) {
+  const lines = body.split('\n');
+  const sections = [];
+  const counters = [0, 0, 0, 0, 0, 0]; // index 0 = H1, index 5 = H6
+
+  let currentTitle  = '(preamble)';
+  let currentNum    = '0';
+  let currentLines  = [];
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)/);
+    if (headingMatch) {
+      // Flush current section
+      const content = currentLines.join('\n').trim();
+      if (content.length > 0) {
+        sections.push({ sectionNum: currentNum, sectionTitle: currentTitle, content });
+      }
+
+      const level = headingMatch[1].length - 1; // 0-indexed
+      counters[level]++;
+      // Reset deeper levels
+      for (let i = level + 1; i < 6; i++) counters[i] = 0;
+
+      currentTitle = headingMatch[2].trim();
+      currentNum   = counters.slice(0, level + 1).filter(n => n > 0).join('.');
+      currentLines = [line]; // heading line goes into this section
+    } else {
+      currentLines.push(line);
+    }
+  }
+
+  // Flush last section
+  const content = currentLines.join('\n').trim();
+  if (content.length > 0) {
+    sections.push({ sectionNum: currentNum, sectionTitle: currentTitle, content });
+  }
+
+  return sections;
+}
+
+function printPolicyStats(stats, ms) {
+  console.log(`policy loader:`);
+  console.log(`  Files read:        ${stats.files}`);
+  console.log(`  Sections parsed:   ${stats.sections}`);
+  console.log(`  Chunks upserted:   ${stats.chunks}`);
+  console.log(`  Chunks embedded:   ${stats.embedded}`);
+  console.log(`  Chunks skipped (hash match, --force not set): ${stats.skipped}`);
+  console.log(`  Errors:            ${stats.errors}`);
+  console.log(`  Duration:          ${(ms / 1000).toFixed(1)}s`);
+  if (dryRun) console.log(`  (dry-run: no DB writes)`);
+}
+
+// ─── ENTRYPOINT ──────────────────────────────────────────────────────────────
+
+main().catch(err => {
+  console.error(`Unhandled error: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/setup-knowledge-db.sql
+++ b/scripts/setup-knowledge-db.sql
@@ -607,7 +607,7 @@ UNION ALL
   SELECT
     'policy_sections'::text,
     ps.id,
-    ps.id,
+    NULL::integer,
     NULL::integer,
     ps.chunk_idx,
     (SELECT COUNT(*)::integer FROM policy_sections ps2 WHERE ps2.doc_id = ps.doc_id AND ps2.section_num IS NOT DISTINCT FROM ps.section_num) AS total_chunks,
@@ -633,7 +633,7 @@ UNION ALL
   FROM session_chunks sc;
 
 COMMENT ON VIEW v_memory_hits IS
-  'Unified semantic-memory search surface across memory_entry_chunks, policy_sections, session_chunks. Use source_row_id for reliable per-source row linkage; parent_id field is intentionally absent because it is semantically incompatible across source tables (entry_id is a row PK, but session_chunks needed session_num — different concept). source_ordinal carries session_num for session_chunks only.';
+  'Unified semantic-memory search surface across memory_entry_chunks, policy_sections, session_chunks. For policy_sections, source_row_id is NULL because policy chunks have no separate parent table; group on (label, source_table) instead. For session_chunks, source_row_id is sc.id (chunk PK, not a parent FK). For memory_entry_chunks, source_row_id is mc.entry_id (parent FK in memory_entries). source_ordinal carries session_num for session_chunks only.';
 
 -- Checklist items — process gates (pre-commit, release-prep, etc.)
 CREATE TABLE IF NOT EXISTS checklist_items (

--- a/scripts/setup-knowledge-db.sql
+++ b/scripts/setup-knowledge-db.sql
@@ -494,6 +494,147 @@ ALTER TABLE policy_sections ADD COLUMN IF NOT EXISTS fts_vec TSVECTOR
 CREATE INDEX IF NOT EXISTS policy_sections_fts_idx ON policy_sections USING gin(fts_vec);
 CREATE INDEX IF NOT EXISTS policy_sections_doc_idx ON policy_sections (doc_id);
 
+-- ─── CHUNKER / LOADER MIGRATION (2026-04-26, issue #142) ────────────────
+-- Adds memory_entry_chunks sibling table, content_hash columns for
+-- incremental sync, HNSW vector indexes for retrieval performance, and
+-- v_memory_hits unified view. See docs/plans/2026-04-26-chunker-loader-plan.md
+
+-- 1. policy_sections — add chunk_idx for sub-chunks of long sections
+ALTER TABLE policy_sections
+  ADD COLUMN IF NOT EXISTS chunk_idx INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE policy_sections
+  ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+-- Replace any prior single-key unique with composite that includes chunk_idx
+DO $$ BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'policy_sections_doc_section_uniq'
+  ) THEN
+    ALTER TABLE policy_sections DROP CONSTRAINT policy_sections_doc_section_uniq;
+  END IF;
+END $$;
+
+ALTER TABLE policy_sections
+  DROP CONSTRAINT IF EXISTS policy_sections_doc_section_chunk_uniq;
+ALTER TABLE policy_sections
+  ADD CONSTRAINT policy_sections_doc_section_chunk_uniq
+  UNIQUE (doc_id, section_num, chunk_idx);
+
+-- 2. session_chunks — add content_hash for incremental sync
+ALTER TABLE session_chunks
+  ADD COLUMN IF NOT EXISTS content_hash TEXT;
+
+-- 3. memory_entry_chunks — new sibling table
+CREATE TABLE IF NOT EXISTS memory_entry_chunks (
+  id          SERIAL PRIMARY KEY,
+  entry_id    INTEGER NOT NULL REFERENCES memory_entries(id) ON DELETE CASCADE,
+  chunk_idx   INTEGER NOT NULL,
+  content     TEXT NOT NULL,
+  content_hash TEXT,
+  created_at  TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (entry_id, chunk_idx)
+);
+
+DO $$ BEGIN
+  ALTER TABLE memory_entry_chunks ADD COLUMN IF NOT EXISTS embedding vector(1024);
+EXCEPTION WHEN undefined_object THEN
+  RAISE NOTICE 'Skipping vector column on memory_entry_chunks — pgvector not installed.';
+END $$;
+
+ALTER TABLE memory_entry_chunks ADD COLUMN IF NOT EXISTS fts_vec TSVECTOR
+  GENERATED ALWAYS AS (to_tsvector('english', coalesce(content, ''))) STORED;
+CREATE INDEX IF NOT EXISTS mem_chunks_fts_idx
+  ON memory_entry_chunks USING gin(fts_vec);
+CREATE INDEX IF NOT EXISTS mem_chunks_entry_idx
+  ON memory_entry_chunks (entry_id);
+
+-- 4. HNSW vector indexes (verdict-required for retrieval performance at scale)
+DO $$ BEGIN
+  CREATE INDEX IF NOT EXISTS mem_chunks_vec_idx
+    ON memory_entry_chunks USING hnsw (embedding vector_cosine_ops);
+EXCEPTION
+  WHEN undefined_object THEN
+    RAISE NOTICE 'Skipping HNSW index on memory_entry_chunks — pgvector not installed.';
+  WHEN feature_not_supported THEN
+    RAISE NOTICE 'HNSW not supported (older pgvector) — falling back to ivfflat.';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS mem_chunks_vec_idx ON memory_entry_chunks USING ivfflat (embedding vector_cosine_ops)';
+END $$;
+
+DO $$ BEGIN
+  CREATE INDEX IF NOT EXISTS session_chunks_vec_idx
+    ON session_chunks USING hnsw (embedding vector_cosine_ops);
+EXCEPTION
+  WHEN undefined_object THEN
+    RAISE NOTICE 'Skipping HNSW index on session_chunks — pgvector not installed.';
+  WHEN feature_not_supported THEN
+    RAISE NOTICE 'HNSW not supported (older pgvector) — falling back to ivfflat.';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS session_chunks_vec_idx ON session_chunks USING ivfflat (embedding vector_cosine_ops)';
+END $$;
+
+DO $$ BEGIN
+  CREATE INDEX IF NOT EXISTS policy_sections_vec_idx
+    ON policy_sections USING hnsw (embedding vector_cosine_ops);
+EXCEPTION
+  WHEN undefined_object THEN
+    RAISE NOTICE 'Skipping HNSW index on policy_sections — pgvector not installed.';
+  WHEN feature_not_supported THEN
+    RAISE NOTICE 'HNSW not supported (older pgvector) — falling back to ivfflat.';
+    EXECUTE 'CREATE INDEX IF NOT EXISTS policy_sections_vec_idx ON policy_sections USING ivfflat (embedding vector_cosine_ops)';
+END $$;
+
+-- 5. v_memory_hits — unified search surface across all three chunk sources
+-- DECISION-001: source_row_id and source_ordinal are explicit; parent_id is
+-- display-only (semantically incompatible across source tables — do not use
+-- for grouping or linkage)
+CREATE OR REPLACE VIEW v_memory_hits AS
+  SELECT
+    'memory_entry_chunks'::text AS source_table,
+    mc.id AS chunk_id,
+    mc.entry_id AS source_row_id,
+    NULL::integer AS source_ordinal,
+    mc.chunk_idx,
+    (SELECT COUNT(*)::integer FROM memory_entry_chunks mc2 WHERE mc2.entry_id = mc.entry_id) AS total_chunks,
+    me.name AS label,
+    substring(mc.content, 1, 300) AS snippet,
+    mc.content,
+    mc.embedding,
+    mc.fts_vec
+  FROM memory_entry_chunks mc
+  JOIN memory_entries me ON me.id = mc.entry_id
+UNION ALL
+  SELECT
+    'policy_sections'::text,
+    ps.id,
+    ps.id,
+    NULL::integer,
+    ps.chunk_idx,
+    (SELECT COUNT(*)::integer FROM policy_sections ps2 WHERE ps2.doc_id = ps.doc_id AND ps2.section_num IS NOT DISTINCT FROM ps.section_num) AS total_chunks,
+    coalesce(ps.doc_id, '') || ' §' || coalesce(ps.section_num, '') AS label,
+    substring(ps.content, 1, 300),
+    ps.content,
+    ps.embedding,
+    ps.fts_vec
+  FROM policy_sections ps
+UNION ALL
+  SELECT
+    'session_chunks'::text,
+    sc.id,
+    sc.id,
+    sc.session_num,
+    sc.chunk_idx,
+    NULL::integer AS total_chunks,
+    coalesce(sc.session_id, '') || ' [' || coalesce(sc.chunk_kind, '') || ']' AS label,
+    substring(sc.content, 1, 300),
+    sc.content,
+    sc.embedding,
+    sc.fts_vec
+  FROM session_chunks sc;
+
+COMMENT ON VIEW v_memory_hits IS
+  'Unified semantic-memory search surface across memory_entry_chunks, policy_sections, session_chunks. Use source_row_id for reliable per-source row linkage; parent_id field is intentionally absent because it is semantically incompatible across source tables (entry_id is a row PK, but session_chunks needed session_num — different concept). source_ordinal carries session_num for session_chunks only.';
+
 -- Checklist items — process gates (pre-commit, release-prep, etc.)
 CREATE TABLE IF NOT EXISTS checklist_items (
   id SERIAL PRIMARY KEY,

--- a/scripts/test-chunker.js
+++ b/scripts/test-chunker.js
@@ -1,0 +1,546 @@
+'use strict';
+
+/**
+ * test-chunker.js — Automated acceptance-gate test runner (DECISION-003)
+ *
+ * Five pathological-input tests that exercise chunkText() and the content_hash
+ * idempotence logic. Exit 0 = all pass; exit 1 = any failure.
+ *
+ * Usage:
+ *   node scripts/test-chunker.js          # Run all 5 tests
+ *   node scripts/test-chunker.js 1        # Run only test 1
+ *   node scripts/test-chunker.js 2 4      # Run only tests 2 and 4
+ *
+ * Plan: docs/plans/2026-04-26-chunker-loader-plan.md §6 + Phase 8
+ */
+
+const assert = require('assert');
+const crypto = require('crypto');
+const path   = require('path');
+
+const { chunkText }   = require('./pipeline-chunker');
+const { encodeCwd }   = require('./lib/encoded-cwd');
+
+// ─── TEST REGISTRY ────────────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+/**
+ * Print a step result: two-column output "  label" + padding + status.
+ * Width is 60 chars for the label column.
+ */
+function step(label, ok, detail) {
+  const pad = Math.max(1, 60 - label.length);
+  const status = ok ? 'OK' : 'FAIL';
+  console.log(`  ${label}${' '.repeat(pad)}${status}`);
+  if (!ok && detail) {
+    console.log(`    Reason: ${detail}`);
+  }
+}
+
+/**
+ * Run one test. The fn must throw on assertion failure.
+ * Returns true on pass, false on fail.
+ */
+async function runTest(num, title, fn) {
+  console.log(`\nTEST ${num} — ${title}`);
+  try {
+    await fn();
+    console.log(`  PASS — Test ${num}`);
+    passed++;
+    return true;
+  } catch (err) {
+    console.log(`  FAIL — Test ${num}`);
+    console.log(`    Reason: ${err.message}`);
+    failed++;
+    return false;
+  }
+}
+
+// ─── FIXTURE GENERATORS ───────────────────────────────────────────────────────
+
+/**
+ * Build a deterministic prose fixture of ~targetLen chars.
+ * Embeds a unique needle phrase in the middle so retrieval can be asserted.
+ * Sentence structure ensures there are valid boundary points for the chunker.
+ */
+function buildProseFixture(targetLen, needle) {
+  // Each sentence is exactly 60 chars when repeated.
+  const sentence = 'This is sentence number NNNNN. It fills out the paragraph. ';
+  const needleInsert = `The unique needle phrase is: ${needle}. `;
+  const lines = [];
+  let total = 0;
+  let sentNum = 0;
+  const midpoint = Math.floor(targetLen / 2);
+
+  while (total < targetLen) {
+    // Insert needle phrase once near the midpoint
+    if (total >= midpoint - 200 && total < midpoint && needle && !lines.join('').includes(needle)) {
+      lines.push(needleInsert);
+      total += needleInsert.length;
+    }
+    const s = sentence.replace('NNNNN', String(sentNum).padStart(5, '0'));
+    lines.push(s);
+    total += s.length;
+    sentNum++;
+    // Add a paragraph break every ~500 chars to give chunker paragraph boundaries
+    if (sentNum % 8 === 0) {
+      lines.push('\n\n');
+      total += 2;
+    }
+  }
+  return lines.join('');
+}
+
+/**
+ * Build a deterministic fixture with multiple H2 sections.
+ * Embeds needle in the specified section index (0-based).
+ */
+function buildSectionedFixture(targetLen, numSections, needle, needleSection) {
+  const perSection = Math.floor(targetLen / numSections);
+  const parts = [];
+  for (let i = 0; i < numSections; i++) {
+    parts.push(`## Section ${i + 1} — Topic ${i + 1}\n\n`);
+    const sectionNeedle = (i === needleSection) ? needle : null;
+    parts.push(buildProseFixture(perSection, sectionNeedle));
+    parts.push('\n\n');
+  }
+  return parts.join('');
+}
+
+/**
+ * Sha256 of text — mirrors the loader's hash function for idempotence tests.
+ */
+function sha256(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+// ─── TEST 1 — Pathological policy section (>8000 chars) ─────────────────────
+
+async function test1() {
+  const NEEDLE   = 'PHRASE_T1_NEEDLE_X42';
+  const CEILING  = 1400;
+  const TARGET   = 8500;
+
+  // 1. Generate fixture
+  step('Generating fixture (8500 chars)...', true);
+  const body = buildProseFixture(TARGET, NEEDLE);
+  assert.ok(body.length >= TARGET,
+    `Fixture too short: ${body.length} < ${TARGET}`);
+  step(`Fixture generated (${body.length} chars, needle embedded)`, true);
+
+  // 2. Chunk with 1400-char ceiling
+  const chunks = chunkText(body, CEILING, 'prose');
+  const maxLen = Math.max(...chunks.map(c => c.content.length));
+  const ok2 = chunks.length >= 5 && maxLen <= CEILING + 200; // +200 headroom for overlap seed
+  step(
+    `chunkText() produced ${chunks.length} chunks (max ${maxLen} chars)`,
+    ok2,
+    ok2 ? null : `Expected >= 5 chunks all <= ${CEILING + 200} chars`
+  );
+  assert.ok(chunks.length >= 5,
+    `Expected >= 5 chunks for ${body.length}-char prose body at ceiling=${CEILING}, got ${chunks.length}`);
+  for (const ch of chunks) {
+    assert.ok(ch.content.length <= CEILING + 200,
+      `Chunk ${ch.chunkIdx} length ${ch.content.length} exceeds ceiling+overlap (${CEILING + 200})`);
+  }
+
+  // 3. Verify needle is recoverable in at least one chunk
+  const needleFound = chunks.some(ch => ch.content.includes(NEEDLE));
+  step(`Needle phrase recoverable in chunked output`, needleFound,
+    needleFound ? null : `'${NEEDLE}' not found in any chunk`);
+  assert.ok(needleFound, `Needle phrase '${NEEDLE}' not found in any chunk`);
+
+  // 4. Verify chunk indices are contiguous from 0
+  for (let i = 0; i < chunks.length; i++) {
+    assert.strictEqual(chunks[i].chunkIdx, i,
+      `Expected chunkIdx ${i}, got ${chunks[i].chunkIdx}`);
+  }
+  step(`Chunk indices are contiguous from 0`, true);
+
+  // 5. Verify coverage: all chars from source appear in chunk output (joined)
+  const joined = chunks.map(c => c.content).join('');
+  // At minimum, the needle must be in the joined output
+  assert.ok(joined.includes(NEEDLE), `Needle not in joined chunk output`);
+  step(`Chunks cover full source (needle present in joined output)`, true);
+}
+
+// ─── TEST 2 — Pathological memory body (>20000 chars) ───────────────────────
+
+async function test2() {
+  const NEEDLE         = 'PHRASE_T2_NEEDLE_Y77';
+  const CEILING        = 1400;
+  const TARGET         = 21000;
+  const NUM_SECTIONS   = 10;
+  const NEEDLE_SECTION = 4; // 0-indexed — 5th section
+
+  // 1. Generate fixture
+  step('Generating fixture (21000 chars, 10 sections)...', true);
+  const body = buildSectionedFixture(TARGET, NUM_SECTIONS, NEEDLE, NEEDLE_SECTION);
+  assert.ok(body.length >= TARGET,
+    `Fixture too short: ${body.length} < ${TARGET}`);
+  step(`Fixture generated (${body.length} chars, needle in section ${NEEDLE_SECTION + 1})`, true);
+
+  // 2. Chunk with 1400-char ceiling
+  const chunks = chunkText(body, CEILING, 'prose');
+  const maxLen = Math.max(...chunks.map(c => c.content.length));
+  const ok2 = chunks.length >= 5 && maxLen <= CEILING + 200;
+  step(
+    `chunkText() produced ${chunks.length} chunks (max ${maxLen} chars)`,
+    ok2,
+    ok2 ? null : `Expected >= 5 chunks all <= ${CEILING + 200} chars`
+  );
+  assert.ok(chunks.length >= 5,
+    `Expected >= 5 chunks for ${body.length}-char body at ceiling=${CEILING}, got ${chunks.length}`);
+  for (const ch of chunks) {
+    assert.ok(ch.content.length <= CEILING + 200,
+      `Chunk ${ch.chunkIdx} length ${ch.content.length} exceeds ceiling+overlap (${CEILING + 200})`);
+  }
+
+  // 3. Needle is in a chunk at index >= 3 (it's in the 5th section which
+  //    should produce chunks well past the start of the output).
+  const needleChunkIdx = chunks.findIndex(ch => ch.content.includes(NEEDLE));
+  const ok3 = needleChunkIdx >= 3;
+  step(
+    `Needle phrase found in chunk index ${needleChunkIdx} (expected >= 3)`,
+    ok3,
+    ok3 ? null : `Needle found in chunk ${needleChunkIdx}, expected >= 3`
+  );
+  assert.ok(needleChunkIdx >= 0, `Needle '${NEEDLE}' not found in any chunk`);
+  assert.ok(ok3,
+    `Needle at chunk ${needleChunkIdx}, expected >= 3 (needle is in section 5 of 10)`);
+}
+
+// ─── TEST 3 — Pathological session message (>4000 chars in JSONL) ─────────────
+
+async function test3() {
+  const NEEDLE  = 'PHRASE_T3_NEEDLE_Z99';
+  const CEILING = 560;
+
+  // 1. Generate a ~4500-char content string with JSON-like content + fenced blocks.
+  //    Represents a tool_result message with mixed code and prose.
+  //
+  //    Structure: alternating prose paragraphs (~400 chars each) and fenced code
+  //    blocks (~80 chars each), separated by double-newlines so rule 3 (paragraph)
+  //    and rule 2 (fence) fire instead of rule 5 (hard-split). This ensures the
+  //    fence-integrity assertion is testing rule 2 path, not the hard-split edge case.
+  step('Generating fixture (4500 chars, fenced code block)...', true);
+  const bt = '```';
+  // Fenced block: ~80 chars, opens and closes cleanly
+  const fencedBlock = `\n\n${bt}json\n{"key": "value", "items": [1, 2, 3], "status": "ok"}\n${bt}\n\n`;
+  // Prose paragraph: ~400 chars (7 sentences of ~57 chars each)
+  const prosePara = 'Tool output paragraph with explanation. It covers the results clearly. ' +
+    'Each sentence adds context. The response was successful. More detail follows here. ' +
+    'Additional findings are included below. Final notes round out the paragraph.\n\n';
+  const parts = [];
+  let total = 0;
+  let blockNum = 0;
+  while (total < 4500) {
+    // Inject needle phrase in the middle prose paragraph
+    if (total >= 2000 && total < 2500 && !parts.join('').includes(NEEDLE)) {
+      const needleLine = `The unique phrase ${NEEDLE} appears in this paragraph. `;
+      parts.push(needleLine);
+      total += needleLine.length;
+    }
+    parts.push(prosePara);
+    total += prosePara.length;
+    if (total < 4200) {
+      parts.push(fencedBlock);
+      total += fencedBlock.length;
+    }
+    blockNum++;
+  }
+  const content = parts.join('');
+  assert.ok(content.length >= 4000,
+    `Fixture too short: ${content.length} < 4000`);
+  step(`Fixture generated (${content.length} chars with fenced blocks and needle)`, true);
+
+  // 2. Chunk with 560-char ceiling in tool_result mode
+  const chunks = chunkText(content, CEILING, 'tool_result');
+  assert.ok(chunks.length >= 2,
+    `Expected >= 2 chunks for ${content.length}-char tool_result, got ${chunks.length}`);
+
+  // 3. No chunk exceeds 560 + 20% headroom (= 672 chars)
+  const HEADROOM = Math.ceil(CEILING * 1.2);
+  const maxLen = Math.max(...chunks.map(c => c.content.length));
+  const ok3 = maxLen <= HEADROOM;
+  step(
+    `chunkText() produced ${chunks.length} chunks (max ${maxLen} chars, limit ${HEADROOM})`,
+    ok3,
+    ok3 ? null : `Max chunk length ${maxLen} exceeds limit ${HEADROOM}`
+  );
+  for (const ch of chunks) {
+    assert.ok(ch.content.length <= HEADROOM,
+      `Chunk ${ch.chunkIdx} length ${ch.content.length} exceeds ${HEADROOM} (120% of ceiling=${CEILING})`);
+  }
+
+  // 4. Verify fence integrity: no chunk has an UNCLOSED opening fence.
+  // A chunk bisects a fence if it contains an opening ``` that has no
+  // corresponding closing ``` within the same chunk. A chunk that contains
+  // only a closing ``` (or only prose) is fine — the chunker is allowed to
+  // split before/after a complete fence block.
+  let fenceIntegrityOk = true;
+  let badChunkInfo = null;
+  for (const ch of chunks) {
+    const lines = ch.content.split('\n');
+    let inFence = false;
+    for (const line of lines) {
+      if (line.startsWith('```')) {
+        inFence = !inFence;
+      }
+    }
+    if (inFence) {
+      // inFence=true after scanning means there's an unclosed opening fence
+      fenceIntegrityOk = false;
+      const fenceCount = lines.filter(l => l.startsWith('```')).length;
+      badChunkInfo = `chunk ${ch.chunkIdx} has unclosed opening fence (${fenceCount} fence line(s))`;
+      break;
+    }
+  }
+  step(`No chunk has an unclosed opening code fence`,
+    fenceIntegrityOk, badChunkInfo);
+  assert.ok(fenceIntegrityOk,
+    `Code fence bisected: ${badChunkInfo}`);
+
+  // 5. Needle recoverable in chunks
+  const needleFound = chunks.some(ch => ch.content.includes(NEEDLE));
+  step(`Needle phrase recoverable in chunked output`, needleFound,
+    needleFound ? null : `'${NEEDLE}' not found in any chunk`);
+  assert.ok(needleFound, `Needle phrase '${NEEDLE}' not found in any chunk`);
+}
+
+// ─── TEST 4 — Idempotence (content_hash logic simulation) ────────────────────
+
+async function test4() {
+  // Simulate two loader runs against identical source text.
+  // On first run: hash stored = null → embed call made (mocked).
+  // On second run: stored hash matches computed hash → embed call skipped.
+
+  step('Simulating loader first-run with no stored hashes...', true);
+
+  const sourceText = 'Idempotence test content. '.repeat(60); // ~1560 chars
+  const chunks = chunkText(sourceText, 1400, 'prose');
+  assert.ok(chunks.length >= 1, `Expected >= 1 chunk, got ${chunks.length}`);
+
+  // Simulate stored hash table: maps chunkIdx -> stored_hash (null = no row yet)
+  const storedHashes = new Map();
+  let embedCallCount = 0;
+
+  function simulateLoaderRun(storedHashMap) {
+    let embedded = 0;
+    let skipped  = 0;
+    const newHashMap = new Map();
+    for (const chunk of chunks) {
+      const computed = sha256(chunk.content);
+      const stored   = storedHashMap.get(chunk.chunkIdx) || null;
+      if (stored === computed) {
+        skipped++;
+      } else {
+        embedCallCount++;
+        embedded++;
+      }
+      newHashMap.set(chunk.chunkIdx, computed);
+    }
+    return { embedded, skipped, newHashMap };
+  }
+
+  // First run — all hashes are absent → all chunks should be "embedded"
+  const run1 = simulateLoaderRun(storedHashes);
+  step(`Run 1: embedded ${run1.embedded} chunks, skipped ${run1.skipped}`,
+    run1.embedded === chunks.length && run1.skipped === 0,
+    `Expected embedded=${chunks.length} skipped=0, got embedded=${run1.embedded} skipped=${run1.skipped}`);
+  assert.strictEqual(run1.embedded, chunks.length,
+    `Run 1: expected all ${chunks.length} chunks embedded, got ${run1.embedded}`);
+  assert.strictEqual(run1.skipped, 0,
+    `Run 1: expected 0 skipped, got ${run1.skipped}`);
+
+  // Second run — use the hashes from run 1 → all should be skipped
+  step('Simulating loader second-run with stored hashes (no source change)...', true);
+  const run2 = simulateLoaderRun(run1.newHashMap);
+  step(`Run 2: embedded ${run2.embedded} chunks, skipped ${run2.skipped}`,
+    run2.embedded === 0 && run2.skipped === chunks.length,
+    `Expected embedded=0 skipped=${chunks.length}, got embedded=${run2.embedded} skipped=${run2.skipped}`);
+  assert.strictEqual(run2.embedded, 0,
+    `Run 2: expected 0 embedded (hash match), got ${run2.embedded}`);
+  assert.strictEqual(run2.skipped, chunks.length,
+    `Run 2: expected all ${chunks.length} skipped, got ${run2.skipped}`);
+
+  // Total embed calls = only first-run chunks
+  step(
+    `Total embed calls: ${embedCallCount} (expected ${chunks.length}, second run = 0)`,
+    embedCallCount === chunks.length,
+    `Expected exactly ${chunks.length} embed calls total, got ${embedCallCount}`
+  );
+  assert.strictEqual(embedCallCount, chunks.length,
+    `Expected embed calls = ${chunks.length} (first run only), got ${embedCallCount}`);
+
+  // Row count identical between runs (both end with same chunk count)
+  step('Row count identical between runs', true);
+}
+
+// ─── TEST 5 — Partial failure resilience ─────────────────────────────────────
+
+async function test5() {
+  // Simulate BATCH=8 embed loop where one chunk has a bad embedding response
+  // (empty array) and a healthy companion chunk embeds successfully.
+
+  const BATCH = 8;
+
+  step('Constructing bad (2000-char CJK) and healthy chunks...', true);
+
+  // Bad chunk: 2000 CJK characters (well above 512-token Ollama limit for CJK ~1 char/token)
+  const badContent  = '啊'.repeat(2000);
+  // Healthy chunk: normal English phrase
+  const goodContent = 'normal english test phrase ' + Date.now();
+
+  const chunks = [
+    { chunkIdx: 9999, content: badContent,  id: 9999 },
+    { chunkIdx: 9998, content: goodContent, id: 9998 },
+  ];
+
+  // Mock ollamaEmbed: for the bad chunk (by index in batch), throw an error simulating
+  // Ollama refusing an oversized input. For the healthy chunk, return a valid 1024-d vector.
+  const mockVector = Array.from({ length: 1024 }, (_, i) => (i + 1) / 1024);
+
+  async function mockOllamaEmbed(texts, origContents) {
+    // Simulate: if the original chunk content is predominantly CJK and > 512 chars,
+    // reject. origContents is a parallel array of raw chunk content (without prefix).
+    // If not provided, fall back to checking the full text for CJK density.
+    const results = [];
+    for (let idx = 0; idx < texts.length; idx++) {
+      const raw = (origContents && origContents[idx]) || texts[idx];
+      // CJK density: true if > 50% of chars are Han characters and length > 512
+      const hanCount = (raw.match(/\p{Script=Han}/gu) || []).length;
+      const isCjkHeavy = hanCount > raw.length * 0.5 && raw.length > 512;
+      if (isCjkHeavy) {
+        throw new Error(
+          `Ollama returned ${texts.length - 1} embeddings for ${texts.length} inputs ` +
+          `(likely context overrun — chunk text smaller before retry)`
+        );
+      }
+      results.push(mockVector);
+    }
+    return results;
+  }
+
+  // Simulate the loader's per-chunk error-isolation pattern (BATCH=8 window):
+  // If the batch-level embed fails, retry each chunk individually so healthy
+  // chunks still get embedded.
+  const embeddedIds  = [];
+  const erroredIds   = [];
+  const errorLog     = [];
+
+  step('Running BATCH=8 embed loop with per-chunk error isolation...', true);
+
+  for (let i = 0; i < chunks.length; i += BATCH) {
+    const batch    = chunks.slice(i, i + BATCH);
+    const texts    = batch.map(ch => `Memory: test\n\n${ch.content}`);
+    const contents = batch.map(ch => ch.content); // raw content for CJK detection
+    const ids      = batch.map(ch => ch.id);
+
+    try {
+      await mockOllamaEmbed(texts, contents);
+      // If batch succeeded, all are embedded
+      for (const id of ids) embeddedIds.push(id);
+    } catch (batchErr) {
+      // Batch failed — retry each chunk individually
+      for (let j = 0; j < batch.length; j++) {
+        try {
+          await mockOllamaEmbed([texts[j]], [contents[j]]);
+          embeddedIds.push(ids[j]);
+        } catch (chunkErr) {
+          errorLog.push(`[SKIP] chunk_idx=${batch[j].chunkIdx} err=${chunkErr.message.slice(0, 80)}`);
+          erroredIds.push(ids[j]);
+        }
+      }
+    }
+  }
+
+  // Assertions:
+  // (a) Bad chunk (9999) has errored — embedding not written
+  const badErrored = erroredIds.includes(9999);
+  step(`Bad chunk (9999, CJK 2000 chars) produced embed error`,
+    badErrored,
+    badErrored ? null : `Expected chunk 9999 to error; errored=[${erroredIds}]`);
+  assert.ok(badErrored,
+    `Bad chunk 9999 should have errored but did not. errored=[${erroredIds}]`);
+
+  // (b) Healthy chunk (9998) succeeded
+  const goodEmbedded = embeddedIds.includes(9998);
+  step(`Healthy chunk (9998, English) embedded successfully despite bad companion`,
+    goodEmbedded,
+    goodEmbedded ? null : `Expected chunk 9998 to embed; embedded=[${embeddedIds}]`);
+  assert.ok(goodEmbedded,
+    `Healthy chunk 9998 should have embedded but did not. embedded=[${embeddedIds}]`);
+
+  // (c) Error logged with chunk identity
+  const hasLog = errorLog.length > 0 && errorLog.some(l => l.includes('chunk_idx=9999'));
+  step(`Error log contains chunk identity for the bad chunk`,
+    hasLog,
+    hasLog ? null : `No log entry for chunk_idx=9999; log=${JSON.stringify(errorLog)}`);
+  assert.ok(hasLog,
+    `Expected error log to mention chunk_idx=9999; got: ${JSON.stringify(errorLog)}`);
+
+  // (d) Loader did not abort — both results accounted for
+  assert.strictEqual(embeddedIds.length + erroredIds.length, chunks.length,
+    `Expected ${chunks.length} total outcomes, got ${embeddedIds.length + erroredIds.length}`);
+  step(`Loader did not abort — all ${chunks.length} chunks accounted for`, true);
+
+  // Bonus: CP3 — Windows encoded-cwd path round-trip (fits naturally here as the
+  // plan's Task 8.7 is listed as part of the test suite)
+  step('CP3: encodeCwd POSIX path round-trip', true);
+  const posixResult = encodeCwd('/home/user/dev/pipeline');
+  assert.strictEqual(posixResult, '-home-user-dev-pipeline',
+    `POSIX encodeCwd: expected '-home-user-dev-pipeline', got '${posixResult}'`);
+
+  step('CP3: encodeCwd Windows path round-trip', true);
+  const winResult = encodeCwd('C:\\Users\\djwmo\\dev\\pipeline');
+  assert.strictEqual(winResult, 'C--Users-djwmo-dev-pipeline',
+    `Windows encodeCwd: expected 'C--Users-djwmo-dev-pipeline', got '${winResult}'`);
+}
+
+// ─── MAIN ─────────────────────────────────────────────────────────────────────
+
+const ALL_TESTS = [
+  { num: 1, title: 'Pathological policy section >8000 chars',      fn: test1 },
+  { num: 2, title: 'Pathological memory body >20000 chars',        fn: test2 },
+  { num: 3, title: 'Pathological session message >4000 chars JSONL', fn: test3 },
+  { num: 4, title: 'Idempotence — content_hash skip logic',        fn: test4 },
+  { num: 5, title: 'Partial failure resilience — BATCH=8 isolation', fn: test5 },
+];
+
+async function main() {
+  // Parse which tests to run: "node test-chunker.js 2 4" → [2, 4]
+  const args = process.argv.slice(2).map(Number).filter(n => n >= 1 && n <= 5);
+  const toRun = args.length > 0
+    ? ALL_TESTS.filter(t => args.includes(t.num))
+    : ALL_TESTS;
+
+  console.log('');
+  for (const t of toRun) {
+    await runTest(t.num, t.title, t.fn);
+  }
+
+  console.log('');
+  console.log('='.repeat(60));
+  const total = passed + failed;
+  if (failed === 0) {
+    console.log(`SUMMARY: ${passed}/${total} tests passed`);
+  } else {
+    const failedNums = ALL_TESTS
+      .filter(t => toRun.includes(t))
+      .filter((_, i) => {
+        // We can't easily track which test failed by number here since runTest
+        // modifies global counters — use a simpler approach below.
+      });
+    console.log(`SUMMARY: ${passed}/${total} tests passed (${failed} failed)`);
+  }
+  console.log('='.repeat(60));
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error(`\nUnhandled error: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a two-part chunker/loader system that resolves Ollama context-overrun failures when embedding large memory tables. The chunker (`scripts/pipeline-chunker.js`) splits prose, JSONL, and policy text at heading and paragraph boundaries with hard byte ceilings; the loader (`scripts/pipeline-memory-loader.js`) drives it against `memory_entries`, `session_chunks`, and `policy_sections`. Against this project's real data — 171 memory entries, 486 session messages, 33 policy sections — the loader produced **690/690 chunks embedded, 0 errors**, inverting a prior 100% failure rate in a context-overrun scenario. Per the debate verdict, the chunker ships first; the longer-context embedder swap (`bge-m3`) is deferred to a separate spec.

## Cycle (truthful scope report)

- [x] Spec authored — `docs/specs/2026-04-26-chunking-loader-spec.md` (351 lines)
- [x] Debate verdict — `docs/findings/debate-2026-04-26-chunking-loader.md` (proceed-with-constraints; 4 HIGH risks; 12 plan-must amendments)
- [x] Plan — `docs/plans/2026-04-26-chunker-loader-plan.md` (350 lines, 9 phases)
- [x] Phase 1 chunker — pure-function, 342 lines, 9 inline asserts pass
- [x] Phase 2 schema migration — applied to pipeline_pipeline; HNSW indexes verified
- [x] Phases 3-4 — encoded-cwd utility (8 round-trip tests pass) + ollamaEmbed empty/zero-vector validation
- [x] Phase 5 loader — 583 lines; live runs: memory 60→171, sessions 13→486, policy 2→33; idempotent re-run skips all (0 Ollama calls in 0.4 s)
- [x] Phase 6 cmdHybrid + cmdSearch updated to query `v_memory_hits` with `[source_table]` prefix and `chunk N/M` indicator
- [x] Phase 7 docs — `docs/memory.md` loader-shipped section; `CHANGELOG.md` [Unreleased] entry
- [x] Phase 8 test-chunker.js — 5/5 pass on pathological inputs (8522-char policy, 21574-char memory, 4730-char tool_result JSONL, idempotence, partial-failure resilience)
- [x] Pre-finish review — 2 blockers fixed in `a2eb35b` (per-chunk retry isolation, `v_memory_hits` semantic clarity)

## Test plan — acceptance gate (DECISION-003)

```
TEST 1 — Pathological policy section >8000 chars  PASS
TEST 2 — Pathological memory body >20000 chars     PASS
TEST 3 — Pathological session message >4000 chars  PASS
TEST 4 — Idempotence — content_hash skip logic    PASS
TEST 5 — Partial failure resilience — BATCH=8     PASS
SUMMARY: 5/5 tests passed
```

**Scope qualifier (per `feedback_ground_in_reality.md`):** the 5 acceptance tests in `test-chunker.js` exercise chunker logic (boundary rules, content_hash skip simulation, BATCH=8 retry pattern with mock Ollama overrun) but do NOT perform full end-to-end DB→Ollama→retrieval round-trips. The complementary E2E validation came from running the actual loader against this project's real data — 690 chunks across all three tables embedded successfully, idempotence verified, hybrid search returns chunked results with chunk-position indicators. Both modes complement; neither alone is sufficient.

## Live retrieval check

`node scripts/pipeline-embed.js hybrid "chunker boundary rules markdown heading"` returns:
- `[session_chunks]` results from real session JSONL transcripts (chunked)
- `[memory_entry_chunks]` results with `chunk N/M` position indicator
- `[policy_sections]` results from chunked CLAUDE.md sections
- Existing per-table sections (`code_index`, `workflow_discovery`, `decisions`, `gotchas`, etc.) unchanged

## Decisions made (from debate verdict)

- **DECISION-001** — `v_memory_hits` SQL view kept (over JS UNION ALL). `source_row_id` and `source_ordinal` explicit; `parent_id` removed. Per-source semantics documented in COMMENT (B2 fix in `a2eb35b`).
- **DECISION-002** — SHA256 `content_hash` column on all three chunk tables; idempotent re-runs make zero Ollama calls. `--force` flag available for full rebuild.
- **DECISION-003** — `scripts/test-chunker.js` ships as automated acceptance gate (5/5 pass).
- **DECISION-004** — `chunkText(text, ceilingChars, contentType)` — loader passes 560 for JSONL (2.5 chars/token), 1400 for prose (4 chars/token).

## Out of scope (deferred)

- Strategy B — longer-context embedder swap (`bge-m3` 1024-dim or `nomic-embed-text-v1.5` 768-dim). Separate spec; the chunker is the load-bearing piece and ships first per the verdict.
- Loaders for `incidents`, `checklist_items`, `corpus_files` — no natural filesystem source-of-truth.
- PDF/binary extraction for `corpus_files`.
- Search ranking (RRF weight) tuning.

## Schema migration

- Adds `memory_entry_chunks` sibling table with `embedding vector(1024)` + `fts_vec` + GIN + HNSW indexes
- Adds `policy_sections.chunk_idx INTEGER NOT NULL DEFAULT 0`, `content_hash TEXT`
- Adds `session_chunks.content_hash TEXT`
- Adds HNSW vector indexes on all three chunk tables (verdict-required for sequential-scan avoidance at scale)
- Creates `v_memory_hits` view as unified search surface

All DDL idempotent (`IF NOT EXISTS`, `CREATE OR REPLACE VIEW`, `DO $$ EXCEPTION` pgvector guards). Safe against existing data.

## Closes

- Closes #142
- Marks Postgres task #60 done
- Resolves the gap flagged in `docs/memory.md:248` ("Pipeline does not ship a loader for these six tables") for three of six tables

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)