### PR TITLE
feat(ergonomics): Phase 3a — extract embedWithRetry shared helper with MAX_EMBED_BYTES guard

### DIFF
--- a/scripts/pipeline-embed.js
+++ b/scripts/pipeline-embed.js
@@ -160,6 +160,11 @@ const TABLES = [
   },
 ];
 
+// ─── EMBED CONSTANTS ─────────────────────────────────────────────────────────
+
+// Safety guard for mxbai-embed-large 512-token cap (~4 chars/token, with margin).
+const MAX_EMBED_BYTES = 2000;
+
 // ─── CHUNK-COVERED TABLES ────────────────────────────────────────────────────
 // Derived from information_schema at first use; cached for the process lifetime.
 // Tables covered by v_memory_hits view — embedded as chunks, not as parent rows.
@@ -202,6 +207,87 @@ async function hasAnyEmbeddings(client, tableName) {
   return rows.length > 0;
 }
 
+// ─── EMBED WITH RETRY ────────────────────────────────────────────────────────
+
+/**
+ * Batch-embed rows with oversize guard, per-batch failure isolation, and
+ * per-row exponential-backoff retry.
+ *
+ * @param {Array}    rows                  - Array of { id, text, ...passthrough } objects.
+ *                                           Caller must set row.text before calling.
+ * @param {Function} embedFn               - async (string[]) => number[][] — one vector per input.
+ * @param {object}   [opts]
+ * @param {number}   [opts.batchSize=32]   - Number of rows per Ollama call.
+ * @param {number}   [opts.maxRetries=3]   - Per-row retry attempts after batch failure.
+ * @param {Function} [opts.onBatchError]   - (err, batch) => void — called on batch rejection.
+ * @returns {Promise<{ embedded: number, skipped: number, failed: number }>}
+ *   Successful rows have row._vector set (pgvector string "[v0,v1,...]").
+ */
+async function embedWithRetry(rows, embedFn, { batchSize = 32, maxRetries = 3, onBatchError = null } = {}) {
+  let embedded = 0;
+  let skipped  = 0;
+  let failed   = 0;
+
+  // Partition: skip rows whose text exceeds MAX_EMBED_BYTES
+  const eligible  = [];
+  const oversized = [];
+  for (const row of rows) {
+    if ((row.text || '').length > MAX_EMBED_BYTES) {
+      oversized.push(row);
+    } else {
+      eligible.push(row);
+    }
+  }
+
+  for (const row of oversized) {
+    process.stderr.write(
+      `[embedWithRetry] Skipping row id=${row.id}: ${(row.text || '').length} chars exceeds MAX_EMBED_BYTES (${MAX_EMBED_BYTES})\n`
+    );
+    skipped++;
+  }
+
+  // Process eligible rows in batches
+  for (let i = 0; i < eligible.length; i += batchSize) {
+    const batch = eligible.slice(i, i + batchSize);
+    const texts = batch.map(r => r.text || '');
+
+    try {
+      const embeddings = await embedFn(texts);
+      for (let j = 0; j < batch.length; j++) {
+        batch[j]._vector = `[${embeddings[j].join(',')}]`;
+        embedded++;
+      }
+    } catch (batchErr) {
+      if (onBatchError) onBatchError(batchErr, batch);
+
+      // Per-row retry with exponential backoff (2s / 4s / 8s)
+      for (const row of batch) {
+        let rowEmbedded = false;
+        for (let attempt = 1; attempt <= maxRetries; attempt++) {
+          const delayMs = Math.pow(2, attempt) * 1000; // 2s, 4s, 8s
+          await new Promise(res => setTimeout(res, delayMs));
+          try {
+            const [vec] = await embedFn([row.text || '']);
+            row._vector = `[${vec.join(',')}]`;
+            embedded++;
+            rowEmbedded = true;
+            break;
+          } catch (retryErr) {
+            if (attempt === maxRetries) {
+              process.stderr.write(
+                `[embedWithRetry] Failed row id=${row.id} after ${maxRetries} retries: ${retryErr.message.slice(0, 100)}\n`
+              );
+            }
+          }
+        }
+        if (!rowEmbedded) failed++;
+      }
+    }
+  }
+
+  return { embedded, skipped, failed };
+}
+
 // ─── INDEX ───────────────────────────────────────────────────────────────────
 
 async function cmdIndex(forceAll) {
@@ -236,35 +322,28 @@ async function cmdIndex(forceAll) {
 
       console.log(`${c.bold('Embedding')} ${rows.length} ${tbl.name} entries via ${EMBED_MODEL}...`);
 
-      const BATCH = 32;
-      let done = 0;
-      try {
-        for (let i = 0; i < rows.length; i += BATCH) {
-          const batch = rows.slice(i, i + BATCH);
-          const texts = batch.map(tbl.textFn);
-          const embeddings = await ollamaEmbed(texts, CONFIG);
-
-          if (embeddings.length !== batch.length) {
-            throw new Error(
-              `Ollama returned ${embeddings.length} embeddings for a batch of ${batch.length} ` +
-              `(table: ${tbl.name}, batch offset: ${i}). ` +
-              `This may indicate a context-length overrun. Try reducing BATCH size or truncating long text fields.`
-            );
-          }
-
-          for (let j = 0; j < batch.length; j++) {
-            const vec = `[${embeddings[j].join(',')}]`;
-            await client.query(tbl.updateSql, [vec, batch[j][tbl.idCol]]);
-            done++;
-            process.stdout.write(`\r  ${done}/${rows.length} embedded...`);
-          }
-        }
-        console.log(`\n${c.green('Done.')} ${tbl.name}: ${done} entries embedded.`);
-      } catch (err) {
-        console.error(`\n${c.red(`Error embedding ${tbl.name}:`)} ${err.message}`);
-        console.error(c.dim(`  ${done} rows written before failure. Re-run "index" to resume.`));
+      // Pre-compute text for each row so embedFn is a pure (texts) => vectors call
+      for (const row of rows) {
+        row.text   = tbl.textFn(row);
+        row.id     = row[tbl.idCol]; // embedWithRetry expects row.id
       }
-      totalDone += done;
+
+      const embedFn = (texts) => ollamaEmbed(texts, CONFIG);
+
+      const result = await embedWithRetry(rows, embedFn, { batchSize: 32 });
+
+      // Write successfully embedded rows to DB
+      let done = 0;
+      for (const row of rows) {
+        if (row._vector) {
+          await client.query(tbl.updateSql, [row._vector, row[tbl.idCol]]);
+          done++;
+          process.stdout.write(`\r  ${done}/${rows.length} embedded...`);
+        }
+      }
+
+      console.log(`\n${c.green('Done.')} ${tbl.name}: ${result.embedded} embedded, ${result.skipped} skipped (oversize), ${result.failed} failed.`);
+      totalDone += result.embedded;
     }
 
     console.log(`\n${c.bold('Total:')} ${totalDone} entries embedded across all tables.`);
@@ -574,8 +653,13 @@ Requires: Ollama running at ${OLLAMA_HOST}:${OLLAMA_PORT}
 `);
 }
 
+// ─── EXPORTS ─────────────────────────────────────────────────────────────────
+
+module.exports = { embedWithRetry, MAX_EMBED_BYTES };
+
 // ─── ENTRY ───────────────────────────────────────────────────────────────────
 
+if (require.main === module) {
 const [, , cmd, ...args] = process.argv;
 
 (async () => {
@@ -606,3 +690,4 @@ const [, , cmd, ...args] = process.argv;
     process.exit(1);
   }
 })();
+} // end require.main === module

--- a/scripts/pipeline-memory-loader.js
+++ b/scripts/pipeline-memory-loader.js
@@ -31,6 +31,7 @@ const crypto = require('crypto');
 const { chunkText }          = require('./pipeline-chunker');
 const { getClaudeProjectDir } = require('./lib/encoded-cwd');
 const { loadConfig, connect, c, ollamaEmbed } = require('./lib/shared');
+const { embedWithRetry }                       = require('./pipeline-embed');
 
 const BATCH                = 8;
 const CONST_PROSE_CEILING  = 1400;  // DECISION-004: prose sources
@@ -155,40 +156,27 @@ async function embedPending(db, config, table, buildCtx, stats) {
 
   if (rows.length === 0) return;
 
-  for (let i = 0; i < rows.length; i += BATCH) {
-    const batch = rows.slice(i, i + BATCH);
-    const texts = batch.map(buildCtx);
+  // Pre-compute text for each row so embedFn is a pure (texts) => vectors call
+  for (const row of rows) {
+    row.text = buildCtx(row);
+  }
 
-    try {
-      const embeddings = await ollamaEmbed(texts, config && config.knowledge);
-      // Happy path: write all embeddings in the batch
-      for (let j = 0; j < batch.length; j++) {
-        const vec = `[${embeddings[j].join(',')}]`;
-        await db.query(
-          `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
-          [vec, batch[j].id]
-        );
-        stats.embedded++;
-      }
-    } catch (batchErr) {
-      // Batch-level failure: fall back to per-chunk individual retry so that
-      // a single oversized chunk doesn't mark healthy chunks as errored.
-      for (let j = 0; j < batch.length; j++) {
-        try {
-          const [vec1] = await ollamaEmbed([texts[j]], config && config.knowledge);
-          const vec = `[${vec1.join(',')}]`;
-          await db.query(
-            `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
-            [vec, batch[j].id]
-          );
-          stats.embedded++;
-        } catch (chunkErr) {
-          stats.errored++;
-          console.error(c.red(`  embed error: table=${table} id=${batch[j].id} chunk_idx=${batch[j].chunk_idx} :: ${chunkErr.message.slice(0, 100)}`));
-        }
-      }
+  const embedFn = (texts) => ollamaEmbed(texts, config && config.knowledge);
+
+  const result = await embedWithRetry(rows, embedFn, { batchSize: BATCH });
+
+  // Write successfully embedded rows to DB
+  for (const row of rows) {
+    if (row._vector) {
+      await db.query(
+        `UPDATE ${table} SET embedding = $1 WHERE id = $2`,
+        [row._vector, row.id]
+      );
+      stats.embedded++;
     }
   }
+
+  stats.errored = (stats.errored || 0) + result.skipped + result.failed;
 }
 
 // ─── MEMORY LOADER ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Phase 3a of the ergonomics-and-robustness sprint (epic #144). Ships **Item 9** — `embedWithRetry` shared helper extracted from the two parallel hand-rolled batch loops in `cmdIndex` and `embedPending`. Phase 3b (CI gate, Item 10) follows as the next and final PR.

**Spec:** `docs/specs/2026-04-26-pipeline-ergonomics-and-robustness-spec.md`
**Plan:** `docs/plans/2026-04-26-pipeline-ergonomics-and-robustness-plan.md`

### Item shipped

`embedWithRetry(rows, embedFn, { batchSize = 32, maxRetries = 3, onBatchError = null })` lives in `scripts/pipeline-embed.js`, exported via `module.exports`, imported by `scripts/pipeline-memory-loader.js`. Both consumers now:
- Skip rows where `text.length > MAX_EMBED_BYTES` (= 2000) with a locked stderr log format.
- Get uniform per-row retry-with-exponential-backoff (2s/4s/8s) on batch failures.
- Return `{ embedded, skipped, failed }` counts; vectors mutated onto `row._vector` for the caller's DB write.

### Plan-vs-reality drifts handled

The plan's Files list named only `scripts/pipeline-embed.js`, but `embedPending` lives in `scripts/pipeline-memory-loader.js:129`. Task 3.1 (orchestrator-inline audit) caught the drift; Task 3.2 dispatch included both files in scope.

### Latent bug caught by smoke test

Adding `module.exports` to a CLI script silently re-runs the CLI on `require()`. Test 6 (full E2E round-trip) flagged it; subagent added `if (require.main === module) main();` guard before commit. Saved as project memory `project_require_main_guard_when_dual_purpose_module.md` so future planner/dispatch prompts include the warning.

### Verification

- `node scripts/test-chunker.js` — 6/6 pass (including Test 6 E2E round-trip)
- `claude plugin validate .` — pass
- Live smoke test: 2560-char `decisions` body produced exact warning `[embedWithRetry] Skipping row id=88: 2560 chars exceeds MAX_EMBED_BYTES (2000)`, batch siblings embedded normally
- Pre-finish review by independent Sonnet subagent — APPROVED, no findings

### Test plan

- [x] test-chunker regression
- [x] plugin validate
- [x] Live MAX_EMBED_BYTES guard smoke test
- [x] CLI still works (`node scripts/pipeline-embed.js index` invocation path)
- [x] Loader still works (test-chunker Test 6 covers the loader → embedPending → DB → retrieval round-trip)
- [x] Pre-finish review

Refs #144 (partial — Phase 3a of 4)
