### PR TITLE
feat(ergonomics): Phase 3b — CI gate (test-chunker.yml) — sprint closing

### DIFF
--- a/.github/workflows/test-chunker.yml
+++ b/.github/workflows/test-chunker.yml
@@ -23,11 +23,16 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: scripts/pnpm-lock.yaml
       - name: Install dependencies
-        run: npm ci
+        run: pnpm install --frozen-lockfile
         working-directory: scripts
       - name: Apply knowledge DB schema
         run: psql -h localhost -U postgres -f scripts/setup-knowledge-db.sql

--- a/.github/workflows/test-chunker.yml
+++ b/.github/workflows/test-chunker.yml
@@ -1,0 +1,40 @@
+name: Test chunker E2E
+# Runs on every pull request to catch regressions before merge.
+# Postgres image is pinned to pg16 to match production instance.
+# Update the image tag AND this comment when upgrading.
+# Ollama is not available in CI; OLLAMA_SKIP=1 skips embedding
+# assertions while structural tests (chunker logic, DB schema,
+# incremental sync) still run.
+on: [pull_request]
+jobs:
+  test-chunker:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+        working-directory: scripts
+      - name: Apply knowledge DB schema
+        run: psql -h localhost -U postgres -f scripts/setup-knowledge-db.sql
+        env:
+          PGPASSWORD: postgres
+      - name: Run chunker tests
+        run: node scripts/test-chunker.js
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost/postgres
+          OLLAMA_SKIP: '1'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -247,3 +247,14 @@ This applies to both:
 After modifying any command or skill:
 1. Run `claude plugin validate .` from the plugin root to verify plugin structure
 2. Test the modified command in a real project with a `.claude/pipeline.yml`
+
+### Embedding pipeline CI gate
+
+`node scripts/test-chunker.js` (6 tests) is the regression gate for the embedding
+pipeline. It runs automatically on every PR via `.github/workflows/test-chunker.yml`.
+
+- When `OLLAMA_SKIP=1` is set, Ollama embedding assertions are skipped; structural
+  tests (chunker logic, DB schema, incremental sync) still run.
+- The CI Postgres service is pinned to `pgvector/pgvector:pg16`. Update the image
+  tag in the workflow file and its comment together when upgrading.
+- `npm ci` runs in `scripts/` (where `package.json` lives), not the repo root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,4 +257,4 @@ pipeline. It runs automatically on every PR via `.github/workflows/test-chunker.
   tests (chunker logic, DB schema, incremental sync) still run.
 - The CI Postgres service is pinned to `pgvector/pgvector:pg16`. Update the image
   tag in the workflow file and its comment together when upgrading.
-- `npm ci` runs in `scripts/` (where `package.json` lives), not the repo root.
+- `pnpm install --frozen-lockfile` runs in `scripts/` (where `package.json` and `pnpm-lock.yaml` live), not the repo root. The project uses pnpm; `package-lock.json` is gitignored — do not switch to `npm ci`.

--- a/scripts/test-chunker.js
+++ b/scripts/test-chunker.js
@@ -28,6 +28,7 @@ const { loadConfig, connect } = require('./lib/shared');
 
 let passed = 0;
 let failed = 0;
+let skipped = 0;
 
 /**
  * Print a step result: two-column output "  label" + padding + status.
@@ -49,7 +50,11 @@ function step(label, ok, detail) {
 async function runTest(num, title, fn) {
   console.log(`\nTEST ${num} — ${title}`);
   try {
-    await fn();
+    const result = await fn();
+    if (result && result.skipped) {
+      skipped++;
+      return 'skipped';
+    }
     console.log(`  PASS — Test ${num}`);
     passed++;
     return true;
@@ -506,6 +511,11 @@ async function test5() {
 // ─── TEST 6 — Real E2E (DB + Ollama + retrieval round-trip) ──────────────────
 
 async function test6() {
+  if (process.env.OLLAMA_SKIP === '1') {
+    console.log('  ⊘ Test 6 — E2E round-trip (skipped: OLLAMA_SKIP=1)');
+    return { skipped: true };
+  }
+
   // Unique needle phrase — Date.now() ensures no cross-run collision in the DB
   const NEEDLE   = `PHRASE_E2E_T6_NEEDLE_${Date.now()}_X42`;
   const TARGET   = 6000;
@@ -713,17 +723,15 @@ async function main() {
 
   console.log('');
   console.log('='.repeat(60));
-  const total = passed + failed;
-  if (failed === 0) {
+  const total = passed + failed + skipped;
+  if (failed === 0 && skipped === 0) {
     console.log(`SUMMARY: ${passed}/${total} tests passed`);
-  } else {
-    const failedNums = ALL_TESTS
-      .filter(t => toRun.includes(t))
-      .filter((_, i) => {
-        // We can't easily track which test failed by number here since runTest
-        // modifies global counters — use a simpler approach below.
-      });
+  } else if (failed === 0) {
+    console.log(`SUMMARY: ${passed} passed, 0 failed, ${skipped} skipped`);
+  } else if (skipped === 0) {
     console.log(`SUMMARY: ${passed}/${total} tests passed (${failed} failed)`);
+  } else {
+    console.log(`SUMMARY: ${passed} passed, ${failed} failed, ${skipped} skipped`);
   }
   console.log('='.repeat(60));
   process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary

Phase 3b of the ergonomics-and-robustness sprint (epic #144). **Sprint-closing PR.** Ships **Item 10** — CI gate via `.github/workflows/test-chunker.yml` running `node scripts/test-chunker.js` on every PR with `pgvector/pgvector:pg16` Postgres service.

**Spec:** `docs/specs/2026-04-26-pipeline-ergonomics-and-robustness-spec.md`
**Plan:** `docs/plans/2026-04-26-pipeline-ergonomics-and-robustness-plan.md`

### Item shipped

`.github/` and `.github/workflows/` are net-new — no CI existed in this repo before this PR. Workflow:
- Triggers on `pull_request`
- Spins up `pgvector/pgvector:pg16` service with health-check
- Sets up Node 20 + pnpm 9 with `pnpm install --frozen-lockfile` (NOT npm — repo uses pnpm)
- Applies `setup-knowledge-db.sql` to the service DB
- Runs `node scripts/test-chunker.js` with `OLLAMA_SKIP=1` so Test 6 (E2E round-trip) skips while Tests 1–5 (structural regression coverage) run

### Plan defects caught and fixed during build

1. **Task 4.1 BLOCKED at pre-flight** — plan workflow set `OLLAMA_SKIP=1` but `test-chunker.js` did not respect the env var. Test 6 called Ollama unconditionally. Precursor `cadda9e` added skip semantics: early-return `{ skipped: true }` from `test6()`; runner reports `SUMMARY: 5 passed, 0 failed, 1 skipped`; exit 0.

2. **Pre-finish review M-1** — plan's `npm ci` step was wrong for this project. `scripts/package-lock.json` is gitignored; the repo uses pnpm with tracked `scripts/pnpm-lock.yaml`. Workflow corrected at `aa21be5` to use `pnpm/action-setup@v4` + `pnpm install --frozen-lockfile`. CLAUDE.md doc updated to match and warn against reverting to `npm ci`.

### Commits

- `cadda9e` test(chunker): respect OLLAMA_SKIP=1 — skip Test 6 E2E when Ollama unavailable (CI precursor)
- `8c98588` feat(ci): add test-chunker.yml workflow — pgvector:pg16 service, OLLAMA_SKIP=1 for CI runs
- `df61548` docs(claude): document embedding-pipeline CI gate behavior, OLLAMA_SKIP semantics, image pinning rule
- `aa21be5` fix(ci): use pnpm install --frozen-lockfile instead of npm ci

### Verification

- `OLLAMA_SKIP=1 node scripts/test-chunker.js` — `SUMMARY: 5 passed, 0 failed, 1 skipped`, exit 0 ✓
- `node scripts/test-chunker.js` (with Ollama) — 6/6 pass ✓
- `claude plugin validate .` — pass ✓
- YAML structurally inspected (top keys, service ports, working-directory, env vars) — all consistent with plan
- Pre-finish review by independent Sonnet subagent — APPROVED_WITH_MEDIUM (M-1 fixed)

### Test plan

- [x] test-chunker pre-flight (OLLAMA_SKIP path produces SKIPPED report; non-skip path 6/6)
- [x] plugin validate
- [x] YAML inspection
- [x] Pre-finish review

### Sprint completion

After this merges, all 11 spec items are shipped:
- Phase 1 (PR #146): Items 1, 2, 3, 4, 5, 6
- Phase 2 (PR #148): Items 7, 8, 11
- Phase 3a (PR #149): Item 9
- **Phase 3b (this PR): Item 10**

**Closes #144** (sprint complete).
