### PR TITLE
feat(architecture): mandate file:line anchors in recon + lint gate (Phase B of #151)

### DIFF
--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -25,8 +25,9 @@ Analyze the codebase and spec to produce architectural decision records that con
 ## Recon Anchor Contract
 
 Every claim in a recon Constraints Block must cite an anchor recognized by
-`scripts/pipeline-lint-recon.js` — `[File: path]`, `[Function: name]`, `[Field: name]`,
-`[Pattern: name]`, `[Library: name]`, or `[Version: x.y.z]`. See `recon-agent-prompt.md`
+`scripts/pipeline-lint-recon.js` — `[File: path]` (or `[File: path:line]`),
+`[Function: name]`, `[Field: name]`, `[Pattern: name]`, or `[Library: name]`.
+See `recon-agent-prompt.md`
 in this skill directory for the full anchor format and per-section requirements. The lint
 is a hard gate: recon output that fails lint blocks downstream planning. The orchestrator
 runs the linter after every recon dispatch and re-dispatches with findings as feedback

--- a/skills/architecture/SKILL.md
+++ b/skills/architecture/SKILL.md
@@ -22,6 +22,16 @@ Analyze the codebase and spec to produce architectural decision records that con
 - Produces decision records artifact, persists to knowledge tier
 - Only relevant domains dispatched (recon determines which).
 
+## Recon Anchor Contract
+
+Every claim in a recon Constraints Block must cite an anchor recognized by
+`scripts/pipeline-lint-recon.js` — `[File: path]`, `[Function: name]`, `[Field: name]`,
+`[Pattern: name]`, `[Library: name]`, or `[Version: x.y.z]`. See `recon-agent-prompt.md`
+in this skill directory for the full anchor format and per-section requirements. The lint
+is a hard gate: recon output that fails lint blocks downstream planning. The orchestrator
+runs the linter after every recon dispatch and re-dispatches with findings as feedback
+(up to 3 iterations) before escalating to the user.
+
 ## Process Flow
 
 ```dot
@@ -74,6 +84,20 @@ Substitutions:
 
 The recon agent returns a **Constraints Block** with: existing stack, established patterns, relevant domains, test coverage, environment requirements.
 
+### Step 1b — Lint recon output
+
+Save the recon agent's output to a temp file, then run the structural linter against it:
+
+```bash
+RECON_FILE="${TMPDIR:-/tmp}/recon-output-${SESSION_ID:-$$}.md"
+# (write recon agent output to $RECON_FILE)
+node scripts/pipeline-lint-recon.js --recon "$RECON_FILE"
+```
+
+If the linter exits non-zero, re-dispatch the recon agent with the lint findings appended
+as a `## Lint Feedback` section in the prompt. Repeat up to **3 iterations total**.
+After iteration 3, halt and escalate to the user — do not proceed to Step 2.
+
 ### Step 2 — Single Architect Pass
 
 Do NOT dispatch a subagent for silent mode. The orchestrator (plan command) reads the recon output and uses it directly as context when generating the implementation plan.
@@ -108,6 +132,12 @@ No separate artifact. Constraints are embedded in the implementation plan as:
 ### Step 1 — Recon
 
 Same as silent mode. Dispatch recon agent, get Constraints Block.
+
+### Step 1b — Lint recon output
+
+Same as silent mode Step 1b. Save output to temp file, run
+`node scripts/pipeline-lint-recon.js --recon <path>`, re-dispatch with findings on
+failure. Maximum **3 iterations**. Escalate to user on iteration 3 failure.
 
 ### Step 2 — Select Relevant Domains
 
@@ -301,6 +331,8 @@ This is NOT a monolithic roadmap. Each decision stands alone with its own invali
 | "This decision is obvious" | Document it anyway. What's obvious to you is context for the build agent. |
 | "The conflicts don't matter" | Cross-domain conflicts become implementation bugs. Resolve them now. |
 | "Silent mode is fine for this LARGE change" | If recon found 3+ relevant domains, use full mode. |
+| "I'll add anchors later" | No. Recon output is gated by `pipeline-lint-recon.js`. Unanchored claims cannot pass the gate. |
+| "The pattern is obviously named-export" | Cite `[File: path]` showing it. The lint allowlist is intentionally narrow — assertion without evidence is rejected. |
 
 ## Issue Tracker Contract
 

--- a/skills/architecture/recon-agent-prompt.md
+++ b/skills/architecture/recon-agent-prompt.md
@@ -104,41 +104,74 @@ Task tool (general-purpose, model: {{MODEL}}):
     A domain is relevant if the codebase has existing patterns in that area OR the spec
     requires new work in that area.
 
+    ## Anchor Format
+
+    Every factual claim in the Constraints Block MUST be anchored with one of the following
+    recognized anchor types. Claims without anchors will be rejected by the lint gate.
+
+    | Anchor | Syntax | Use for |
+    |--------|--------|---------|
+    | File | `[File: path/to/file.ext]` or `[File: path:lineN]` | Any claim backed by a file on disk |
+    | Function | `[Function: name]` | Named function/method found in source |
+    | Field | `[Field: name]` | Struct/object field or DB column |
+    | Pattern | `[Pattern: name]` | Named pattern from the allowlist (see below) |
+    | Library | `[Library: name]` | Dependency from a manifest file |
+    | Version | `[Version: x.y.z]` | Pinned version found in a manifest |
+
+    **Pattern allowlist** (only these values are accepted for `[Pattern: name]`):
+    named-export, default-export, function-component, arrow-component, kebab-case, camelCase,
+    PascalCase, use-client, use-server, feature-based, layer-based, hybrid, raw-sql, orm,
+    query-builder, middleware, repository, factory, singleton.
+
+    **One example per anchor type:**
+    - `[Library: react]` — library named in package.json
+    - `[File: src/lib/auth.ts:14]` — specific line in a source file
+    - `[Function: runSelfTests]` — function found via Grep/Read
+    - `[Field: user_id]` — column or field confirmed in schema
+    - `[Pattern: named-export]` — from the allowlist above
+    - `[Version: 18.3.1]` — version string from a manifest
+
     ## Output Format
 
     ```
     ## Constraints Block
 
     ### Existing Stack
-    [Framework]: [version]
-    [ORM/DB]: [version]
-    [State]: [library + version]
-    [Styling]: [approach]
-    [Testing]: [framework + version]
-    [Auth]: [library or "none"]
-    [Deployment]: [target or "unknown"]
+    Each entry MUST cite [Library: name] and at least one [File: manifest] reference.
+    - [Library: react]: [Version: 18.3.1] — see [File: package.json:25]
+    - [Library: pg]: [Version: 8.11.0] — see [File: scripts/package.json:8]
+    - (repeat for ORM/DB, state, styling, testing, auth, deployment)
 
     ### Established Patterns
-    - [Pattern 1]: [description — e.g., "Components use named exports with Props type suffix"]
-    - [Pattern 2]: [description — e.g., "API routes validate with Zod schemas in shared /schemas dir"]
-    - [Pattern 3]: [description]
-    - ... (list all significant patterns found)
+    Each bullet MUST cite either [File: path] co-cite OR a [Pattern: name] from the allowlist.
+    - Named exports for utilities: [Pattern: named-export] in [File: src/lib/utils.ts]
+    - API validation with Zod: [Pattern: middleware] in [File: src/api/routes/example.ts:10]
+    - (list all significant patterns found — no unanchored assertions)
 
     ### Relevant Domains
-    [DOMAIN_ID]: [reason — e.g., "DATA: Prisma schema exists, spec adds new models"]
-    [DOMAIN_ID]: [reason]
-    ... (only list domains that are actually relevant)
+    Each entry MUST cite at least one [File: path] or [Library: name].
+    - DATA: existing schema in [File: prisma/schema.prisma], queries via [Library: prisma]
+    - UI: components in [File: src/components/], uses [Pattern: function-component]
+    - (only list domains that are actually relevant)
 
     ### Existing Test Coverage
-    - Test framework: [name + config location]
-    - Test organization: [pattern]
+    - Test framework: [Library: vitest] — config at [File: vitest.config.ts]
+    - Test organization: [Pattern: feature-based] — sample: [File: src/__tests__/example.test.ts]
     - Approximate test count: [N files, M test cases]
     - Coverage: [% if configured, "unknown" otherwise]
-    - Fixture pattern: [description or "none"]
+    - Fixture pattern: [description anchored with [File: path] or "none"]
 
     ### Environment Requirements
-    [List env vars needed for the feature, from .env.example analysis]
+    Each env var MUST cite [File: .env.example] or equivalent manifest.
+    - DATABASE_URL — see [File: .env.example:3]
+    - (list all env vars required for the feature)
     ```
+
+    After producing the Constraints Block, the orchestrator will run
+    `node scripts/pipeline-lint-recon.js --recon <path>` against your output.
+    If the lint reports findings, you will be re-dispatched with the findings as
+    feedback for up to 3 iterations. Failure on iteration 3 escalates to the user.
+    Anchor every claim — fabrication is structurally rejected.
 
     <ANTI-RATIONALIZATION>
     These thoughts mean STOP and reconsider:

--- a/skills/architecture/recon-agent-prompt.md
+++ b/skills/architecture/recon-agent-prompt.md
@@ -116,7 +116,8 @@ Task tool (general-purpose, model: {{MODEL}}):
     | Field | `[Field: name]` | Struct/object field or DB column |
     | Pattern | `[Pattern: name]` | Named pattern from the allowlist (see below) |
     | Library | `[Library: name]` | Dependency from a manifest file |
-    | Version | `[Version: x.y.z]` | Pinned version found in a manifest |
+
+    Versions appear inline as prose next to a `[Library: name]` anchor (see Output Format examples) — the lint gate does not validate version strings, only library names.
 
     **Pattern allowlist** (only these values are accepted for `[Pattern: name]`):
     named-export, default-export, function-component, arrow-component, kebab-case, camelCase,
@@ -129,7 +130,6 @@ Task tool (general-purpose, model: {{MODEL}}):
     - `[Function: runSelfTests]` — function found via Grep/Read
     - `[Field: user_id]` — column or field confirmed in schema
     - `[Pattern: named-export]` — from the allowlist above
-    - `[Version: 18.3.1]` — version string from a manifest
 
     ## Output Format
 
@@ -138,8 +138,8 @@ Task tool (general-purpose, model: {{MODEL}}):
 
     ### Existing Stack
     Each entry MUST cite [Library: name] and at least one [File: manifest] reference.
-    - [Library: react]: [Version: 18.3.1] — see [File: package.json:25]
-    - [Library: pg]: [Version: 8.11.0] — see [File: scripts/package.json:8]
+    - [Library: react] 18.3.1 — see [File: package.json:25]
+    - [Library: pg] 8.11.0 — see [File: scripts/package.json:8]
     - (repeat for ORM/DB, state, styling, testing, auth, deployment)
 
     ### Established Patterns


### PR DESCRIPTION
## Summary
- `skills/architecture/SKILL.md`: new `## Recon Anchor Contract` section, `### Step 1b — Lint recon output` under both Silent and Full Mode (3-iteration cap), 2 anti-rationalization rows for anchor discipline.
- `skills/architecture/recon-agent-prompt.md`: new `## Anchor Format` section, rewritten `## Output Format` with mandatory anchors per section, closing lint-loop instruction.
- Pipeline gates recon output on `scripts/pipeline-lint-recon.js` (shipped in PR #152). Fabricated paths/functions/libraries no longer survive into the planner's prompt.

## Pre-finish review
- 1 HIGH and 1 MEDIUM caught during build (invented `[Version:]` anchor type the linter doesn't validate). Both fixed in `09a01f3` + `c642662` before push.
- Final review: SHIP. Internal contract consistent — both files enumerate exactly 5 anchor types (File, Function, Field, Pattern, Library, plus File:line variant), iteration cap is 3 in both, lint-script path consistent.

## Known follow-up (separate PR, this is the "fix this once and for all" work)
The data-driven sections (anchor table, pattern allowlist, iteration cap) are hand-authored here as a temporary state. A generator script will be built that exports these as constants from `pipeline-lint-recon.js` and rewrites the marker-bracketed regions of these two skill files deterministically. Eliminates the agent-restate-the-list drift surface that produced the `[Version:]` invention.

## Test plan
- [x] Internal-consistency review (anchor list match, iteration cap match, script path)
- [x] DATA-tag boundaries preserved
- [x] YAML frontmatter unchanged
- [x] No stale references — `pipeline-lint-recon.js` exists on main at `8503419`

Closes #151. Closes TaskList #26.