### PR TITLE
feat(routing): tear sonnet out of recon-prompt data sections via generator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,22 @@ scripts/                    — Setup scripts (e.g., Postgres knowledge DB)
 - Include red flags and rationalization prevention tables
 - Reference config values as `config.section.key` — never hardcode project-specific values
 
+### Generator-Managed Regions (do not hand-edit between markers)
+
+Some sections of skill files are produced deterministically by `scripts/pipeline-generate-recon-prompt.js` from canonical constants exported by `scripts/pipeline-lint-recon.js`. These sections are wrapped in HTML comment markers:
+
+```
+<!-- BEGIN GENERATED: <region-id> -->
+...content rewritten by the generator...
+<!-- END GENERATED: <region-id> -->
+```
+
+Hand-edits between BEGIN/END markers will be reverted on the next generator run AND fail CI via `node scripts/pipeline-lint-agents.js check-recon-prompt-sync`. To change a generated region, change the canonical source in `pipeline-lint-recon.js` (the exported constants) and run `node scripts/pipeline-generate-recon-prompt.js --write`.
+
+Why: agents reliably hallucinate when asked to restate structured lists (anchor types, allowlist values). Tearing the agent out of that work entirely — generator emits, agent never authors — is the structural fix. See `feedback_aggressive_tooling_over_reasoning.md` and `feedback_self_examination_during_dogfooding.md` in user memory.
+
+Currently region-managed: anchor-type table + pattern allowlist in `skills/architecture/recon-agent-prompt.md`. Future generator-managed regions follow the same marker convention.
+
 ### Routing Fields (Convention-not-reason)
 
 Skills declare three YAML frontmatter fields used by the PreToolUse routing hook (`scripts/hooks/routing-check.js`) to enforce model/tool routing per skill at dispatch time.

--- a/scripts/pipeline-generate-recon-prompt.js
+++ b/scripts/pipeline-generate-recon-prompt.js
@@ -124,8 +124,11 @@ function generateRegion(regionId) {
 
 // ─── MARKER PARSING ──────────────────────────────────────────────────────────
 
-const BEGIN_RE = /^<!-- BEGIN GENERATED: ([a-z0-9-]+) -->$/;
-const END_RE   = /^<!-- END GENERATED: ([a-z0-9-]+) -->$/;
+// Allow leading whitespace so markers can sit inside indented YAML literal
+// blocks (e.g., the `prompt: |` body in skills/architecture/recon-agent-prompt.md).
+// Captured indent is propagated to every emitted line so the YAML scalar stays valid.
+const BEGIN_RE = /^([ \t]*)<!-- BEGIN GENERATED: ([a-z0-9-]+) -->$/;
+const END_RE   = /^([ \t]*)<!-- END GENERATED: ([a-z0-9-]+) -->$/;
 
 /**
  * Parse a file's lines and return an array of regions:
@@ -141,29 +144,33 @@ function parseRegions(lines) {
   const regions = [];
   let openId = null;
   let openIdx = -1;
+  let openIndent = '';
 
   for (let i = 0; i < lines.length; i++) {
     const beginMatch = lines[i].match(BEGIN_RE);
     const endMatch   = lines[i].match(END_RE);
 
     if (beginMatch) {
-      const id = beginMatch[1];
+      const indent = beginMatch[1];
+      const id     = beginMatch[2];
       if (!KNOWN_REGIONS.has(id)) {
         throw new Error(`unknown region id: ${id}`);
       }
-      openId  = id;
-      openIdx = i;
+      openId     = id;
+      openIdx    = i;
+      openIndent = indent;
     } else if (endMatch) {
-      const id = endMatch[1];
+      const id = endMatch[2];
       if (openId === null) {
         throw new Error(`unclosed or mismatched region: ${id}`);
       }
       if (id !== openId) {
         throw new Error(`unclosed or mismatched region: ${openId}`);
       }
-      regions.push({ id, beginLine: openIdx, endLine: i });
-      openId  = null;
-      openIdx = -1;
+      regions.push({ id, beginLine: openIdx, endLine: i, indent: openIndent });
+      openId     = null;
+      openIdx    = -1;
+      openIndent = '';
     }
   }
 
@@ -184,7 +191,12 @@ function parseRegions(lines) {
  * @returns {{ rewritten: string, regionIds: string[] }}
  */
 function computeRewrite(content) {
-  const lines   = content.split('\n');
+  // Detect and preserve the file's line-ending style. Splitting on /\r?\n/
+  // strips trailing \r so the regex anchors match; joining on `eol` writes
+  // back the same style so we never silently flip CRLF→LF (Windows-authored
+  // files in this repo are CRLF; UNIX files are LF).
+  const eol     = content.includes('\r\n') ? '\r\n' : '\n';
+  const lines   = content.split(/\r?\n/);
   const regions = parseRegions(lines);  // throws on error
 
   if (regions.length === 0) {
@@ -195,12 +207,15 @@ function computeRewrite(content) {
   const outLines = [];
   let cursor = 0;
 
-  for (const { id, beginLine, endLine } of regions) {
+  for (const { id, beginLine, endLine, indent } of regions) {
     // Lines before this region (including BEGIN marker)
     outLines.push(...lines.slice(cursor, beginLine + 1));
-    // Fresh generated content
-    outLines.push(...generateRegion(id));
-    // END marker
+    // Fresh generated content, prefixed with the BEGIN marker's leading
+    // whitespace so the region stays inside any enclosing YAML literal block.
+    for (const line of generateRegion(id)) {
+      outLines.push(line.length === 0 ? '' : indent + line);
+    }
+    // END marker (preserved verbatim from input)
     outLines.push(lines[endLine]);
     cursor = endLine + 1;
   }
@@ -208,7 +223,7 @@ function computeRewrite(content) {
   // Remaining lines after last region
   outLines.push(...lines.slice(cursor));
 
-  return { rewritten: outLines.join('\n'), regionIds: regions.map(r => r.id) };
+  return { rewritten: outLines.join(eol), regionIds: regions.map(r => r.id) };
 }
 
 // ─── SELF-TESTS ──────────────────────────────────────────────────────────────
@@ -345,6 +360,35 @@ function runSelfTests() {
       threw = e.message.includes('unknown region id: version-list');
     }
     assert('Test 6: unknown region id throws with correct message', threw);
+  }
+
+  // ── Test 7b: Indented markers — generated content inherits indent ────────
+  {
+    const tmpFile = path.join(os.tmpdir(), `gen-recon-test7b-${Date.now()}.md`);
+    const indented = [
+      'prompt: |',
+      '    Some prose.',
+      '    <!-- BEGIN GENERATED: anchor-table -->',
+      '    placeholder',
+      '    <!-- END GENERATED: anchor-table -->',
+      '    Trailing prose.',
+    ].join('\n');
+    fs.writeFileSync(tmpFile, indented, 'utf8');
+
+    const { rewritten } = computeRewrite(fs.readFileSync(tmpFile, 'utf8'));
+    fs.writeFileSync(tmpFile, rewritten, 'utf8');
+
+    const after = fs.readFileSync(tmpFile, 'utf8').split('\n');
+    const tableHeaderLine = after.find(l => l.includes('| Anchor | Syntax | Use for |'));
+    assert('Test 7b: indented anchor-table header is itself indented 4 spaces',
+      tableHeaderLine !== undefined && tableHeaderLine.startsWith('    | Anchor'));
+    const fileRow = after.find(l => l.includes('| File |'));
+    assert('Test 7b: indented File row also indented 4 spaces',
+      fileRow !== undefined && fileRow.startsWith('    | File |'));
+    assert('Test 7b: BEGIN marker indent preserved',
+      after.some(l => l === '    <!-- BEGIN GENERATED: anchor-table -->'));
+
+    fs.unlinkSync(tmpFile);
   }
 
   // ── Test 7: Unclosed region (BEGIN without END) throws ───────────────────

--- a/scripts/pipeline-generate-recon-prompt.js
+++ b/scripts/pipeline-generate-recon-prompt.js
@@ -1,0 +1,481 @@
+#!/usr/bin/env node
+/**
+ * pipeline-generate-recon-prompt.js — Generator for data-shaped sections in
+ * skills/architecture/recon-agent-prompt.md (and optionally other targets).
+ *
+ * Reads canonical ANCHOR_TYPES and ARCH_PATTERN_ALLOWLIST from
+ * pipeline-lint-recon.js and rewrites HTML-comment-delimited regions in the
+ * target file so those sections can never drift from the linter's own data.
+ *
+ * Usage:
+ *   node scripts/pipeline-generate-recon-prompt.js --write [--target <path>]
+ *   node scripts/pipeline-generate-recon-prompt.js --check [--target <path>]
+ *   node scripts/pipeline-generate-recon-prompt.js --self-test
+ *
+ * Exit codes:
+ *   0 — success / in-sync
+ *   1 — drift detected (--check), target not found, or self-test failure
+ *   2 — malformed input (unknown region id, unclosed region, bad CLI args)
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+const os   = require('os');
+
+const { ANCHOR_TYPES, ARCH_PATTERN_ALLOWLIST } = require('./pipeline-lint-recon');
+
+// ─── ANSI ────────────────────────────────────────────────────────────────────
+
+const c = {
+  bold:   (s) => `\x1b[1m${s}\x1b[0m`,
+  green:  (s) => `\x1b[32m${s}\x1b[0m`,
+  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  red:    (s) => `\x1b[31m${s}\x1b[0m`,
+  cyan:   (s) => `\x1b[36m${s}\x1b[0m`,
+  dim:    (s) => `\x1b[2m${s}\x1b[0m`,
+  info:   (s) => `\x1b[34m${s}\x1b[0m`,
+};
+
+// ─── RENDER DETAIL MAP ───────────────────────────────────────────────────────
+// This is the ONLY literal data owned by this generator.
+// ANCHOR_TYPES (imported) still drives which rows appear.
+
+const ANCHOR_RENDER = {
+  File:     { syntax: '`[File: path/to/file.ext]` (or `[File: path:lineN]`)', useFor: 'Any claim backed by a file on disk' },
+  Function: { syntax: '`[Function: name]`',                                    useFor: 'Named function/method found in source' },
+  Field:    { syntax: '`[Field: name]`',                                       useFor: 'Struct/object field or DB column' },
+  Pattern:  { syntax: '`[Pattern: name]`',                                     useFor: 'Named pattern from the allowlist (see below)' },
+  Library:  { syntax: '`[Library: name]`',                                     useFor: 'Dependency from a manifest file' },
+};
+
+// ─── REGION RENDERERS ────────────────────────────────────────────────────────
+
+/**
+ * Renders the anchor-table region: a markdown table with one row per anchor type.
+ * @returns {string[]} lines (no trailing newline)
+ */
+function renderAnchorTable() {
+  const lines = [
+    '| Anchor | Syntax | Use for |',
+    '|--------|--------|---------|',
+  ];
+  for (const type of ANCHOR_TYPES) {
+    const r = ANCHOR_RENDER[type];
+    lines.push(`| ${type} | ${r.syntax} | ${r.useFor} |`);
+  }
+  return lines;
+}
+
+/**
+ * Renders the pattern-allowlist region: alphabetically sorted tokens, comma-
+ * separated, wrapped to ~85 chars per line, terminated with a period.
+ * @returns {string[]} lines
+ */
+function renderPatternAllowlist() {
+  const sorted = Array.from(ARCH_PATTERN_ALLOWLIST).sort((a, b) =>
+    a.toLowerCase().localeCompare(b.toLowerCase())
+  );
+
+  const MAX_LINE = 85;
+  const lines = [];
+  let current = '';
+
+  for (let i = 0; i < sorted.length; i++) {
+    const token = sorted[i];
+    const isLast = i === sorted.length - 1;
+    const suffix = isLast ? '.' : ',';
+    const piece = current.length === 0 ? token + suffix : ' ' + token + suffix;
+
+    if (current.length > 0 && current.length + piece.length > MAX_LINE) {
+      lines.push(current);
+      current = token + suffix;
+    } else {
+      current = current.length === 0 ? token + suffix : current + ' ' + token + suffix;
+    }
+  }
+
+  if (current.length > 0) {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+// ─── REGION DISPATCH ─────────────────────────────────────────────────────────
+
+const KNOWN_REGIONS = new Set(['anchor-table', 'pattern-allowlist']);
+
+/**
+ * Generate content lines for a given region id.
+ * Throws an Error with message `unknown region id: <id>` for unrecognized ids.
+ * @param {string} regionId
+ * @returns {string[]}
+ */
+function generateRegion(regionId) {
+  switch (regionId) {
+    case 'anchor-table':      return renderAnchorTable();
+    case 'pattern-allowlist': return renderPatternAllowlist();
+    default:
+      throw new Error(`unknown region id: ${regionId}`);
+  }
+}
+
+// ─── MARKER PARSING ──────────────────────────────────────────────────────────
+
+const BEGIN_RE = /^<!-- BEGIN GENERATED: ([a-z0-9-]+) -->$/;
+const END_RE   = /^<!-- END GENERATED: ([a-z0-9-]+) -->$/;
+
+/**
+ * Parse a file's lines and return an array of regions:
+ *   { id, beginLine, endLine }  (0-based indices into `lines`)
+ *
+ * Throws on unclosed or mismatched regions.
+ * Throws on unknown region ids.
+ *
+ * @param {string[]} lines
+ * @returns {{ id: string, beginLine: number, endLine: number }[]}
+ */
+function parseRegions(lines) {
+  const regions = [];
+  let openId = null;
+  let openIdx = -1;
+
+  for (let i = 0; i < lines.length; i++) {
+    const beginMatch = lines[i].match(BEGIN_RE);
+    const endMatch   = lines[i].match(END_RE);
+
+    if (beginMatch) {
+      const id = beginMatch[1];
+      if (!KNOWN_REGIONS.has(id)) {
+        throw new Error(`unknown region id: ${id}`);
+      }
+      openId  = id;
+      openIdx = i;
+    } else if (endMatch) {
+      const id = endMatch[1];
+      if (openId === null) {
+        throw new Error(`unclosed or mismatched region: ${id}`);
+      }
+      if (id !== openId) {
+        throw new Error(`unclosed or mismatched region: ${openId}`);
+      }
+      regions.push({ id, beginLine: openIdx, endLine: i });
+      openId  = null;
+      openIdx = -1;
+    }
+  }
+
+  if (openId !== null) {
+    throw new Error(`unclosed or mismatched region: ${openId}`);
+  }
+
+  return regions;
+}
+
+// ─── CORE REWRITE ────────────────────────────────────────────────────────────
+
+/**
+ * Given the current file content (as a string), produce the rewritten content.
+ * Returns the rewritten string (may be identical to input).
+ *
+ * @param {string} content
+ * @returns {{ rewritten: string, regionIds: string[] }}
+ */
+function computeRewrite(content) {
+  const lines   = content.split('\n');
+  const regions = parseRegions(lines);  // throws on error
+
+  if (regions.length === 0) {
+    return { rewritten: content, regionIds: [] };
+  }
+
+  // Build output by slicing between regions
+  const outLines = [];
+  let cursor = 0;
+
+  for (const { id, beginLine, endLine } of regions) {
+    // Lines before this region (including BEGIN marker)
+    outLines.push(...lines.slice(cursor, beginLine + 1));
+    // Fresh generated content
+    outLines.push(...generateRegion(id));
+    // END marker
+    outLines.push(lines[endLine]);
+    cursor = endLine + 1;
+  }
+
+  // Remaining lines after last region
+  outLines.push(...lines.slice(cursor));
+
+  return { rewritten: outLines.join('\n'), regionIds: regions.map(r => r.id) };
+}
+
+// ─── SELF-TESTS ──────────────────────────────────────────────────────────────
+
+function runSelfTests() {
+  let passed = 0;
+  let failed = 0;
+
+  function assert(label, condition) {
+    if (condition) {
+      console.log(c.green('  PASS') + `  ${label}`);
+      passed++;
+    } else {
+      console.log(c.red('  FAIL') + `  ${label}`);
+      failed++;
+    }
+  }
+
+  // ── Test 1: anchor-table renders 5 rows in correct order ─────────────────
+  {
+    const rows = renderAnchorTable();
+    // header + separator + 5 data rows = 7 lines
+    assert('Test 1: anchor-table has 7 lines (header + sep + 5 rows)', rows.length === 7);
+    assert('Test 1: first data row is File', rows[2].startsWith('| File |'));
+    assert('Test 1: second data row is Function', rows[3].startsWith('| Function |'));
+    assert('Test 1: third data row is Field', rows[4].startsWith('| Field |'));
+    assert('Test 1: fourth data row is Pattern', rows[5].startsWith('| Pattern |'));
+    assert('Test 1: fifth data row is Library', rows[6].startsWith('| Library |'));
+    assert('Test 1: File syntax contains [File: path/to/file.ext]', rows[2].includes('[File: path/to/file.ext]'));
+    assert('Test 1: Pattern use-for references allowlist', rows[5].includes('allowlist'));
+  }
+
+  // ── Test 2: pattern-allowlist renders 19 tokens, alphabetical, period-terminated
+  {
+    const lines = renderPatternAllowlist();
+    const full  = lines.join(' ');
+    // Count commas: 18 commas for 19 items
+    const commaCount = (full.match(/,/g) || []).length;
+    assert('Test 2: pattern-allowlist has 18 commas (19 tokens)', commaCount === 18);
+    assert('Test 2: final char is period', full.trimEnd().endsWith('.'));
+
+    // Verify alphabetical order (case-insensitive)
+    const tokens = full.replace(/[,\.]/g, '').split(/\s+/).filter(Boolean);
+    assert('Test 2: 19 tokens present', tokens.length === 19);
+    let sorted = true;
+    for (let i = 1; i < tokens.length; i++) {
+      if (tokens[i].toLowerCase() < tokens[i - 1].toLowerCase()) {
+        sorted = false; break;
+      }
+    }
+    assert('Test 2: tokens are case-insensitive alphabetical', sorted);
+
+    // No line exceeds 85 chars
+    const overlong = lines.some(l => l.length > 85);
+    assert('Test 2: no line exceeds 85 chars', !overlong);
+  }
+
+  // ── Test 3: --write rewrites a stale region in a tmp file ────────────────
+  {
+    const tmpFile = path.join(os.tmpdir(), `gen-recon-test3-${Date.now()}.md`);
+    const stale = [
+      '# Test',
+      '<!-- BEGIN GENERATED: anchor-table -->',
+      '| Old | Stale | Content |',
+      '<!-- END GENERATED: anchor-table -->',
+      'After',
+    ].join('\n');
+    fs.writeFileSync(tmpFile, stale, 'utf8');
+
+    const { rewritten, regionIds } = computeRewrite(fs.readFileSync(tmpFile, 'utf8'));
+    fs.writeFileSync(tmpFile, rewritten, 'utf8');
+
+    const after = fs.readFileSync(tmpFile, 'utf8');
+    const hasOldContent = after.includes('| Old | Stale | Content |');
+    const hasNewHeader  = after.includes('| Anchor | Syntax | Use for |');
+    assert('Test 3: --write removes stale content', !hasOldContent);
+    assert('Test 3: --write inserts fresh anchor-table header', hasNewHeader);
+    assert('Test 3: regionIds includes anchor-table', regionIds.includes('anchor-table'));
+
+    fs.unlinkSync(tmpFile);
+  }
+
+  // ── Test 4: --check exits 0 when target already matches ──────────────────
+  {
+    const tmpFile = path.join(os.tmpdir(), `gen-recon-test4-${Date.now()}.md`);
+    // Build a file that is already in sync
+    const freshRows    = renderAnchorTable();
+    const freshContent = [
+      '# Test',
+      '<!-- BEGIN GENERATED: anchor-table -->',
+      ...freshRows,
+      '<!-- END GENERATED: anchor-table -->',
+    ].join('\n');
+    fs.writeFileSync(tmpFile, freshContent, 'utf8');
+
+    const current    = fs.readFileSync(tmpFile, 'utf8');
+    const { rewritten } = computeRewrite(current);
+    const inSync = rewritten === current;
+    assert('Test 4: --check exits 0 when target matches', inSync);
+
+    fs.unlinkSync(tmpFile);
+  }
+
+  // ── Test 5: --check exits 1 when target is stale ─────────────────────────
+  {
+    const tmpFile = path.join(os.tmpdir(), `gen-recon-test5-${Date.now()}.md`);
+    const stale = [
+      '# Test',
+      '<!-- BEGIN GENERATED: pattern-allowlist -->',
+      'old content that is wrong',
+      '<!-- END GENERATED: pattern-allowlist -->',
+    ].join('\n');
+    fs.writeFileSync(tmpFile, stale, 'utf8');
+
+    const current = fs.readFileSync(tmpFile, 'utf8');
+    const { rewritten } = computeRewrite(current);
+    const drifted = rewritten !== current;
+    assert('Test 5: --check detects drift on stale content', drifted);
+
+    fs.unlinkSync(tmpFile);
+  }
+
+  // ── Test 6: Unknown region id throws ─────────────────────────────────────
+  {
+    const lines = [
+      '<!-- BEGIN GENERATED: version-list -->',
+      'stuff',
+      '<!-- END GENERATED: version-list -->',
+    ];
+    let threw = false;
+    try {
+      parseRegions(lines);
+    } catch (e) {
+      threw = e.message.includes('unknown region id: version-list');
+    }
+    assert('Test 6: unknown region id throws with correct message', threw);
+  }
+
+  // ── Test 7: Unclosed region (BEGIN without END) throws ───────────────────
+  {
+    const lines = [
+      '<!-- BEGIN GENERATED: anchor-table -->',
+      'some content',
+      '# no end marker here',
+    ];
+    let threw = false;
+    try {
+      parseRegions(lines);
+    } catch (e) {
+      threw = e.message.includes('unclosed or mismatched region');
+    }
+    assert('Test 7: BEGIN without END throws unclosed region error', threw);
+  }
+
+  console.log('');
+  console.log(c.bold(`Self-tests: ${passed} passed, ${failed} failed`));
+  return { passed, failed };
+}
+
+// ─── MAIN CLI ─────────────────────────────────────────────────────────────────
+
+function main() {
+  const argv  = process.argv.slice(2);
+  const quiet = argv.includes('--quiet');
+
+  if (argv.includes('--self-test')) {
+    console.log(c.bold('pipeline-generate-recon-prompt self-tests'));
+    console.log('');
+    const { passed, failed } = runSelfTests();
+    process.exit(failed > 0 ? 1 : 0);
+  }
+
+  const doWrite = argv.includes('--write');
+  const doCheck = argv.includes('--check');
+
+  if (!doWrite && !doCheck) {
+    console.error('Usage: node scripts/pipeline-generate-recon-prompt.js --write|--check [--target <path>] [--quiet]');
+    console.error('       node scripts/pipeline-generate-recon-prompt.js --self-test');
+    process.exit(2);
+  }
+
+  if (doWrite && doCheck) {
+    console.error('pipeline-generate-recon-prompt: --write and --check are mutually exclusive');
+    process.exit(2);
+  }
+
+  // Resolve target path
+  const projectRoot = path.resolve(__dirname, '..');
+  const DEFAULT_TARGET = path.join(projectRoot, 'skills', 'architecture', 'recon-agent-prompt.md');
+
+  let targetPath = DEFAULT_TARGET;
+  const targetIdx = argv.indexOf('--target');
+  if (targetIdx >= 0) {
+    if (!argv[targetIdx + 1]) {
+      console.error('pipeline-generate-recon-prompt: --target requires a path argument');
+      process.exit(2);
+    }
+    const raw = argv[targetIdx + 1];
+    targetPath = path.isAbsolute(raw) ? raw : path.resolve(projectRoot, raw);
+  }
+
+  if (!fs.existsSync(targetPath)) {
+    console.error(`pipeline-generate-recon-prompt: target not found: ${targetPath}`);
+    process.exit(1);
+  }
+
+  let current;
+  try {
+    current = fs.readFileSync(targetPath, 'utf8');
+  } catch (err) {
+    console.error(`pipeline-generate-recon-prompt: error reading target: ${err.message}`);
+    process.exit(1);
+  }
+
+  let rewritten, regionIds;
+  try {
+    ({ rewritten, regionIds } = computeRewrite(current));
+  } catch (err) {
+    const msg = err.message;
+    if (msg.startsWith('unknown region id:') || msg.startsWith('unclosed or mismatched region:')) {
+      console.error(`pipeline-generate-recon-prompt: ${msg}`);
+      process.exit(2);
+    }
+    console.error(`pipeline-generate-recon-prompt: unexpected error: ${msg}`);
+    process.exit(2);
+  }
+
+  const changed = rewritten !== current;
+
+  if (doWrite) {
+    if (changed) {
+      fs.writeFileSync(targetPath, rewritten, 'utf8');
+      if (!quiet) {
+        console.log(`pipeline-generate-recon-prompt: rewrote ${regionIds.length} region(s) in ${targetPath}`);
+      }
+    } else {
+      if (!quiet) {
+        console.log(`pipeline-generate-recon-prompt: ${targetPath} already in sync`);
+      }
+    }
+    process.exit(0);
+  }
+
+  // --check mode
+  if (changed) {
+    const driftedIds = regionIds; // all regions were processed; report those that changed
+    console.error(`pipeline-generate-recon-prompt: ${targetPath} is out of sync; run --write to fix.`);
+    for (const id of driftedIds) {
+      console.error(`  region: ${id}`);
+    }
+    process.exit(1);
+  } else {
+    if (!quiet) {
+      console.log(`pipeline-generate-recon-prompt: ${targetPath} is in sync.`);
+    }
+    process.exit(0);
+  }
+}
+
+// ─── EXPORTS ─────────────────────────────────────────────────────────────────
+
+module.exports = {
+  computeRewrite,
+  generateRegion,
+  renderAnchorTable,
+  renderPatternAllowlist,
+  parseRegions,
+};
+
+if (require.main === module) { main(); }

--- a/scripts/pipeline-generate-recon-prompt.js
+++ b/scripts/pipeline-generate-recon-prompt.js
@@ -50,6 +50,27 @@ const ANCHOR_RENDER = {
   Library:  { syntax: '`[Library: name]`',                                     useFor: 'Dependency from a manifest file' },
 };
 
+// Module-load invariant: ANCHOR_TYPES (canonical, imported) and ANCHOR_RENDER
+// (this generator's render details) must agree on the set of keys. If
+// pipeline-lint-recon.js ever adds an anchor type without a matching render
+// entry here, fail loudly at startup rather than throw an opaque TypeError
+// inside renderAnchorTable.
+{
+  const renderKeys = new Set(Object.keys(ANCHOR_RENDER));
+  const typesSet   = new Set(ANCHOR_TYPES);
+  const missing    = ANCHOR_TYPES.filter(t => !renderKeys.has(t));
+  const extra      = Object.keys(ANCHOR_RENDER).filter(k => !typesSet.has(k));
+  if (missing.length || extra.length) {
+    const parts = [];
+    if (missing.length) parts.push(`missing render entries: ${missing.join(', ')}`);
+    if (extra.length)   parts.push(`stale render entries: ${extra.join(', ')}`);
+    throw new Error(
+      `pipeline-generate-recon-prompt: ANCHOR_TYPES and ANCHOR_RENDER are out of sync — ${parts.join('; ')}. ` +
+      `Update ANCHOR_RENDER in this file to match the canonical ANCHOR_TYPES exported by pipeline-lint-recon.js.`
+    );
+  }
+}
+
 // ─── REGION RENDERERS ────────────────────────────────────────────────────────
 
 /**
@@ -127,8 +148,10 @@ function generateRegion(regionId) {
 // Allow leading whitespace so markers can sit inside indented YAML literal
 // blocks (e.g., the `prompt: |` body in skills/architecture/recon-agent-prompt.md).
 // Captured indent is propagated to every emitted line so the YAML scalar stays valid.
-const BEGIN_RE = /^([ \t]*)<!-- BEGIN GENERATED: ([a-z0-9-]+) -->$/;
-const END_RE   = /^([ \t]*)<!-- END GENERATED: ([a-z0-9-]+) -->$/;
+// Trailing whitespace after `-->` is tolerated so editors that auto-trim or
+// auto-pad lines don't silently defeat marker detection.
+const BEGIN_RE = /^([ \t]*)<!-- BEGIN GENERATED: ([a-z0-9-]+) -->[ \t]*$/;
+const END_RE   = /^([ \t]*)<!-- END GENERATED: ([a-z0-9-]+) -->[ \t]*$/;
 
 /**
  * Parse a file's lines and return an array of regions:
@@ -360,6 +383,19 @@ function runSelfTests() {
       threw = e.message.includes('unknown region id: version-list');
     }
     assert('Test 6: unknown region id throws with correct message', threw);
+  }
+
+  // ── Test 7a: Trailing whitespace after --> still matches markers ─────────
+  {
+    const lines = [
+      '<!-- BEGIN GENERATED: anchor-table -->   ',
+      'placeholder',
+      '<!-- END GENERATED: anchor-table -->\t',
+    ];
+    let regions;
+    try { regions = parseRegions(lines); } catch (e) { regions = null; }
+    assert('Test 7a: BEGIN with trailing spaces matches', regions !== null && regions.length === 1);
+    assert('Test 7a: END with trailing tab matches', regions !== null && regions[0].id === 'anchor-table');
   }
 
   // ── Test 7b: Indented markers — generated content inherits indent ────────

--- a/scripts/pipeline-lint-agents.js
+++ b/scripts/pipeline-lint-agents.js
@@ -557,6 +557,43 @@ function checkOperationClass() {
 
 // ─── MAIN ────────────────────────────────────────────────────────────────────
 
+// ─── CHECK RECON-PROMPT GENERATOR SYNC ──────────────────────────────────────
+
+function checkReconPromptSync() {
+  const { computeRewrite } = require('./pipeline-generate-recon-prompt');
+  const target = path.join(PLUGIN_ROOT, 'skills', 'architecture', 'recon-agent-prompt.md');
+  if (!fs.existsSync(target)) {
+    console.log(c.green(`  PASS  recon-agent-prompt.md not found — no regions to check.`));
+    return;
+  }
+  const current = fs.readFileSync(target, 'utf8');
+  let rewritten, regionIds;
+  try {
+    ({ rewritten, regionIds } = computeRewrite(current));
+  } catch (err) {
+    console.log(c.red(`  FAIL  pipeline-generate-recon-prompt: ${err.message}`));
+    process.exit(1);
+  }
+  if (rewritten === current) {
+    const n = regionIds.length;
+    console.log(c.green(`  PASS  recon-agent-prompt.md generator regions in sync (${n} region${n === 1 ? '' : 's'}).`));
+    console.log(c.bold(c.green(`\nGenerator regions in sync.`)));
+    return;
+  }
+  const finding = {
+    id:         'LA-GEN-001',
+    severity:   'HIGH',
+    confidence: 'HIGH',
+    file:       path.relative(PLUGIN_ROOT, target).replace(/\\/g, '/'),
+    line:       0,
+    checkId:    'recon-prompt-generator-drift',
+    message:    `Generator regions out of sync with pipeline-lint-recon.js exports. Run \`node scripts/pipeline-generate-recon-prompt.js --write\` to regenerate.`,
+  };
+  console.log(c.red(formatFinding(finding)));
+  console.log(c.bold(c.red(`\nGenerator regions out of sync.`)));
+  process.exit(1);
+}
+
 function main() {
   const args = process.argv.slice(2);
   const command = args[0];
@@ -571,10 +608,16 @@ function main() {
     return;
   }
 
+  if (command === 'check-recon-prompt-sync') {
+    checkReconPromptSync();
+    return;
+  }
+
   if (command !== 'lint') {
     console.log(`Usage: node pipeline-lint-agents.js lint [--changed] [--json] [--files "f1 f2"] [--exclude "pattern1,pattern2"]`);
     console.log(`       node pipeline-lint-agents.js check-operation-class`);
     console.log(`       node pipeline-lint-agents.js check-prompt-size`);
+    console.log(`       node pipeline-lint-agents.js check-recon-prompt-sync`);
     process.exit(0);
   }
 

--- a/scripts/pipeline-lint-recon.js
+++ b/scripts/pipeline-lint-recon.js
@@ -51,6 +51,16 @@ class Finding {
   }
 }
 
+// ─── ANCHOR VOCABULARY (canonical — exported for downstream generators) ─────
+// The five anchor types this linter recognizes. [File: ...] additionally
+// supports a `:line` variant (e.g., [File: scripts/foo.js:42]); that is a
+// validator-level detail, not a separate anchor type.
+const ANCHOR_TYPES = ['File', 'Function', 'Field', 'Pattern', 'Library'];
+
+// Recommended retry cap for orchestrators that re-dispatch a recon agent
+// after a failing lint pass. Architecture skill's Step 1b uses this value.
+const MAX_LINT_ITERATIONS = 3;
+
 // ─── PATTERN ALLOWLIST ───────────────────────────────────────────────────────
 
 const ARCH_PATTERN_ALLOWLIST = new Set([
@@ -1054,6 +1064,9 @@ module.exports = {
   parseLineAnchors,
   lintConstraintsBlock,
   Finding,
+  ANCHOR_TYPES,
+  ARCH_PATTERN_ALLOWLIST,
+  MAX_LINT_ITERATIONS,
 };
 
 // ─── ENTRY POINT ─────────────────────────────────────────────────────────────

--- a/skills/architecture/recon-agent-prompt.md
+++ b/skills/architecture/recon-agent-prompt.md
@@ -109,20 +109,24 @@ Task tool (general-purpose, model: {{MODEL}}):
     Every factual claim in the Constraints Block MUST be anchored with one of the following
     recognized anchor types. Claims without anchors will be rejected by the lint gate.
 
+    <!-- BEGIN GENERATED: anchor-table -->
     | Anchor | Syntax | Use for |
     |--------|--------|---------|
-    | File | `[File: path/to/file.ext]` or `[File: path:lineN]` | Any claim backed by a file on disk |
+    | File | `[File: path/to/file.ext]` (or `[File: path:lineN]`) | Any claim backed by a file on disk |
     | Function | `[Function: name]` | Named function/method found in source |
     | Field | `[Field: name]` | Struct/object field or DB column |
     | Pattern | `[Pattern: name]` | Named pattern from the allowlist (see below) |
     | Library | `[Library: name]` | Dependency from a manifest file |
+    <!-- END GENERATED: anchor-table -->
 
     Versions appear inline as prose next to a `[Library: name]` anchor (see Output Format examples) — the lint gate does not validate version strings, only library names.
 
     **Pattern allowlist** (only these values are accepted for `[Pattern: name]`):
-    named-export, default-export, function-component, arrow-component, kebab-case, camelCase,
-    PascalCase, use-client, use-server, feature-based, layer-based, hybrid, raw-sql, orm,
-    query-builder, middleware, repository, factory, singleton.
+    <!-- BEGIN GENERATED: pattern-allowlist -->
+    arrow-component, camelCase, default-export, factory, feature-based,
+    function-component, hybrid, kebab-case, layer-based, middleware, named-export, orm,
+    PascalCase, query-builder, raw-sql, repository, singleton, use-client, use-server.
+    <!-- END GENERATED: pattern-allowlist -->
 
     **One example per anchor type:**
     - `[Library: react]` — library named in package.json


### PR DESCRIPTION
## Summary

Eliminates the agent-restate-the-list drift surface that produced the `[Version:]` anchor invention in PR #153. Instead of having Sonnet author the anchor table and pattern allowlist in `skills/architecture/recon-agent-prompt.md`, those data sections are now wrapped in `<!-- BEGIN GENERATED: ... -->` markers and rewritten deterministically by `scripts/pipeline-generate-recon-prompt.js` from constants exported by `scripts/pipeline-lint-recon.js`.

The agent never authors the data again. CI gates drift via a new `pipeline-lint-agents.js check-recon-prompt-sync` sub-check.

## What's in this PR (6 commits)

1. `pipeline-lint-recon.js` exports `ANCHOR_TYPES`, `ARCH_PATTERN_ALLOWLIST`, `MAX_LINT_ITERATIONS` as canonical constants.
2. New `scripts/pipeline-generate-recon-prompt.js` (~525 lines, 25 self-tests) — `--write`, `--check`, `--self-test`, `--target`, `--quiet`. Two recognized region IDs: `anchor-table`, `pattern-allowlist`.
3. CRLF line-ending preservation + indented-marker support (auto-detects BEGIN line's leading whitespace, applies to all emitted lines so YAML literal blocks stay valid).
4. Marker insertion + canonicalization in `recon-agent-prompt.md` (File row gets `(or ...)` parens, allowlist alphabetized).
5. New `check-recon-prompt-sync` sub-check in `pipeline-lint-agents.js` reporting LA-GEN-001 (HIGH) on drift.
6. Forward-proofing: module-load invariant on `ANCHOR_TYPES`/`ANCHOR_RENDER` key agreement; trailing-whitespace tolerance on markers.
7. CLAUDE.md documents the Generator-Managed Regions convention.

## Why this exists (user instruction, verbatim)

> "is there a way for the inaccuracies to be avoided via python/node? use a tool instead of reasoning?" — 2026-04-26 20:43 UTC, planning ceremony
>
> "no, if they reliably hallucinate that means it doesn't belong in an agent - it belongs in a tool." — 2026-04-27 03:38 UTC
>
> "are you building bumpers for an agent to not get a gutterball or are you fully replacing the logic into a tool where it belongs? More guardrails aren't the answer here - firing the agent from the job is." — 2026-04-27

This PR fires the agent from the job.

## Test plan

- [x] `node scripts/pipeline-generate-recon-prompt.js --self-test` — 25/25 passing
- [x] `node scripts/pipeline-lint-recon.js --self-test` — still 12/12 (exports added, no behavior change)
- [x] `node scripts/pipeline-lint-agents.js check-recon-prompt-sync` — exit 0
- [x] `--check` correctly reports drift when the file is corrupted (verified during build)
- [x] CRLF round-trip preserves line endings (file is CRLF; --write maintains it)
- [x] Indented markers in YAML literal block produce indented generated content

Pre-finish review (independent Sonnet): SHIP. Two MEDIUMs (forward-proofing gaps) fixed in `d1d222d` before push.

## Follow-up

The same drift surface exists for `pipeline-lint-plan.js` ↔ `skills/qa/SKILL.md` ↔ `skills/planning/SKILL.md` (anchor types + Task ID format). Audit + retrofit in a separate PR.

Closes #154.