### PR TITLE
fix(embed): register memory_entry_chunks + drop chunk-table skip

### DIFF
--- a/scripts/pipeline-embed.js
+++ b/scripts/pipeline-embed.js
@@ -101,8 +101,12 @@ const TABLES = [
   {
     name: 'memory_entry_chunks',
     idCol: 'id',
-    textFn: (r) => r.content || '',
-    selectCols: 'id, entry_id, chunk_idx, content',
+    // Embed with parent-name context to match the loader's inline embedPending
+    // path (pipeline-memory-loader.js:295, "Memory: ${name}\n\n${content}").
+    // Without the parent name, backfilled chunks have weaker embeddings than
+    // chunks embedded during the load pass.
+    textFn: (r) => `Memory: ${r.entry_name || ''}\n\n${r.content || ''}`,
+    selectCols: 'id, entry_id, chunk_idx, content, (SELECT name FROM memory_entries WHERE id = entry_id) AS entry_name',
     updateSql: 'UPDATE memory_entry_chunks SET embedding = $1 WHERE id = $2',
     label: (r) => `memory entry #${r.entry_id} chunk ${r.chunk_idx}`,
     snippet: (r) => (r.content || '').substring(0, 120),

--- a/scripts/pipeline-embed.js
+++ b/scripts/pipeline-embed.js
@@ -99,6 +99,16 @@ const TABLES = [
     ftsCol: 'fts_vec',
   },
   {
+    name: 'memory_entry_chunks',
+    idCol: 'id',
+    textFn: (r) => r.content || '',
+    selectCols: 'id, entry_id, chunk_idx, content',
+    updateSql: 'UPDATE memory_entry_chunks SET embedding = $1 WHERE id = $2',
+    label: (r) => `memory entry #${r.entry_id} chunk ${r.chunk_idx}`,
+    snippet: (r) => (r.content || '').substring(0, 120),
+    ftsCol: 'fts_vec',
+  },
+  {
     name: 'gotchas',
     idCol: 'id',
     textFn: (r) => `${r.issue || ''} ${r.rule || ''}`,
@@ -167,8 +177,12 @@ const MAX_EMBED_BYTES = 2000;
 
 // ─── CHUNK-COVERED TABLES ────────────────────────────────────────────────────
 // Derived from information_schema at first use; cached for the process lifetime.
-// Tables covered by v_memory_hits view — embedded as chunks, not as parent rows.
-// cmdIndex skips these to avoid Ollama context-overrun on long parent-row bodies.
+// Tables covered by v_memory_hits view (the *_chunks tables).
+// Used by cmdSearch / cmdHybrid to skip per-table iteration for chunk tables —
+// their hits are surfaced via v_memory_hits and would otherwise double-count.
+// cmdIndex no longer skips chunk tables: they have small per-row content and
+// embed cleanly, and the loader's inline embed path is not always exercised
+// (e.g., when consumers populate chunks via their own ingest layers).
 let _chunkTablesCached = null;
 
 async function getChunkTables(client) {
@@ -295,7 +309,6 @@ async function cmdIndex(forceAll) {
   try {
     let totalDone = 0;
 
-    const chunkTables = await getChunkTables(client);
     for (const tbl of TABLES) {
       if (!(await tableExists(client, tbl.name))) {
         console.log(c.dim(`Skipping ${tbl.name} — table does not exist.`));
@@ -303,10 +316,6 @@ async function cmdIndex(forceAll) {
       }
       if (!(await columnExists(client, tbl.name, 'embedding'))) {
         console.log(c.dim(`Skipping ${tbl.name} — no embedding column. Run setup to add it.`));
-        continue;
-      }
-      if (chunkTables.has(tbl.name)) {
-        console.log(c.dim(`Skipping ${tbl.name} — covered by v_memory_hits chunks.`));
         continue;
       }
 


### PR DESCRIPTION
## Summary

Closes #156. Closes Gap #1 from \`pipeline-handoff-policy-framework-gaps-2026-04-28.md\`.

PR #143 added the \`memory_entry_chunks\` table and the chunker that writes to it, but \`pipeline-embed.js\` never knew to embed those rows. Two coupled changes for \`pipeline-embed.js index\` to actually backfill chunk-table embeddings:

1. Adds a TABLES entry for \`memory_entry_chunks\` mirroring \`session_chunks\`. Uses a correlated subquery in selectCols to pull \`memory_entries.name\` so backfilled chunks match the loader's inline embed format (\`Memory: \${name}\n\n\${content}\`) — no degraded-quality embeddings.
2. Drops the \"skip if in chunkTables\" guard in \`cmdIndex\`. The skip predates chunk-table embedding via the loader and assumed chunks were never indexed by cmdIndex. That assumption breaks for consumers (e.g., policy-framework) that populate \`memory_entry_chunks\` via their own ingest layer, leaving \`embedding IS NULL\` forever. WHERE-IS-NULL guard makes the catch-up idempotent.

\`cmdSearch\` / \`cmdHybrid\` still skip chunk tables in TABLES iteration to avoid double-counting hits already surfaced via \`v_memory_hits\`.

## Why band-aid by design

Static-TABLES pattern is structurally wrong; the right fix is a separate engine project where consumers register their own chunk tables. See \`plans/synchronous-finding-bear.md\`. This patch unblocks policy-framework today; removed when the engine extraction lands.

## Pre-finish review (cycle: fix → re-review → push)

- bce1806: SHIP-WITH-NOTES + 1 MEDIUM (textFn missing parent-name context).
- daca634: subquery + textFn fix. Re-review: CONFIRMED-CLEAN.

## Test plan

- [x] \`PROJECT_ROOT=\$(pwd) node scripts/test-chunker.js\` — all 6 scenarios pass including E2E round-trip
- [x] Module parses cleanly
- [x] Static-source-constant constraint preserved
- [ ] CI workflow on push